### PR TITLE
Fix favicon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/logo-picture_CHaM3jFR.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SoftHire - Automate Regulatory Reporting End-to-End</title>
     <meta name="description" content="SoftHire is a regtech platform that automates regulatory reporting from data collection to submission. Specializing in Immigration Compliance and FCA compliance solutions." />


### PR DESCRIPTION
## Summary
- use existing `logo-picture_CHaM3jFR.png` as the favicon instead of missing `vite.svg`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f7bfd39b883339cf69b4e9685e4e8