### PR TITLE
Link 'Get Notified' buttons to contact section

### DIFF
--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -72,9 +72,12 @@ const Products = () => {
                 ))}
               </div>
 
-              <button className="mt-8 w-full bg-navy-700 text-white py-3 px-6 rounded-lg hover:bg-navy-800 transition-colors font-semibold">
+              <a
+                href="#contact"
+                className="mt-8 w-full bg-navy-700 text-white py-3 px-6 rounded-lg hover:bg-navy-800 transition-colors font-semibold block text-center"
+              >
                 Get Notified
-              </button>
+              </a>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- update product cards so the Get Notified buttons jump to the contact section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688408aa68ac8333a176bfc1fc1432c4