### PR TITLE
Synchronize header and footer logos

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Menu, X, ShieldCheck } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -10,7 +10,11 @@ const Header = () => {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex items-center space-x-2">
-            <ShieldCheck className="h-8 w-8 text-gold-500" />
+            <img
+              src="/logo-picture_CHaM3jFR.png"
+              alt="SoftHire Logo"
+              className="h-8 w-auto scale-x-150"
+            />
             <span className="text-white font-semibold text-2xl">SoftHire</span>
           </div>
 


### PR DESCRIPTION
## Summary
- replace the header's `ShieldCheck` icon with the arrow image used in the footer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688610c4fbac833394fd54206936857b