### PR TITLE
Update hero messaging and recruitment link

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,8 +7,8 @@ const Hero = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center max-w-4xl mx-auto">
           <h1 className="text-4xl md:text-6xl font-bold text-navy-900 mb-6 leading-tight">
-            Automate <br className="md:hidden" />
-            Sponsor-Licence Filings <span className="text-gold-500">Now</span>
+            Simplify <br className="md:hidden" />
+            Sponsorship <span className="text-gold-500">Compliance</span>
           </h1>
           
           <p className="text-xl md:text-2xl text-navy-600 mb-8 leading-relaxed">

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -38,7 +38,7 @@ const Products = () => {
         'Visa application support',
         'Industry-specific job boards'
       ],
-      link: '/recruitment'
+      link: '#contact'
     }
   ];
 


### PR DESCRIPTION
## Summary
- update hero headline on front page
- link the Sponsored Recruitment Platform card directly to the contact form

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a592420dc8333a5a22dbb2fb83d20