### PR TITLE
Refocus hero and products on recruitment and sponsor licenses

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,15 +19,18 @@ const Header = () => {
             <a href="#products" className="text-white hover:text-gold-400 transition-colors font-medium">
               Products
             </a>
+            <a href="/recruitment" className="text-white hover:text-gold-400 transition-colors font-medium">
+              Recruitment
+            </a>
             <a href="#about" className="text-white hover:text-gold-400 transition-colors font-medium">
               About
             </a>
             <a href="#contact" className="text-white hover:text-gold-400 transition-colors font-medium">
               Contact
             </a>
-            <button className="bg-navy-700 text-white px-6 py-2 rounded-lg hover:bg-navy-800 transition-colors font-medium">
-              Get Started
-            </button>
+            <a href="/recruitment" className="bg-navy-700 text-white px-6 py-2 rounded-lg hover:bg-navy-800 transition-colors font-medium">
+              Start Recruiting
+            </a>
           </nav>
 
           {/* Mobile menu button */}
@@ -46,15 +49,18 @@ const Header = () => {
               <a href="#products" className="text-white hover:text-gold-400 transition-colors font-medium">
                 Products
               </a>
+              <a href="/recruitment" className="text-white hover:text-gold-400 transition-colors font-medium">
+                Recruitment
+              </a>
               <a href="#about" className="text-white hover:text-gold-400 transition-colors font-medium">
                 About
               </a>
               <a href="#contact" className="text-white hover:text-gold-400 transition-colors font-medium">
                 Contact
               </a>
-              <button className="bg-navy-700 text-white px-6 py-2 rounded-lg hover:bg-navy-800 transition-colors font-medium w-fit">
-                Get Started
-              </button>
+              <a href="/recruitment" className="bg-navy-700 text-white px-6 py-2 rounded-lg hover:bg-navy-800 transition-colors font-medium w-fit">
+                Start Recruiting
+              </a>
             </div>
           </div>
         )}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,42 +8,43 @@ const Hero = () => {
         <div className="text-center max-w-4xl mx-auto">
           <h1 className="text-4xl md:text-6xl font-bold text-navy-900 mb-6 leading-tight">
             Simplify <br className="md:hidden" />
-            Sponsorship <span className="text-gold-500">Compliance</span>
+            Sponsorship <span className="text-gold-500">Compliance</span> &
+            Recruitment
           </h1>
-          
+
           <p className="text-xl md:text-2xl text-navy-600 mb-8 leading-relaxed">
-            SoftHire streamlines compliance from data collection to submission, 
-            helping businesses navigate complex regulatory requirements with confidence.
+            SoftHire streamlines sponsor license applications and connects you with qualified global talent,
+            helping businesses navigate compliance and recruitment with confidence.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <a
-              href="#contact"
+              href="/recruitment"
               className="bg-navy-700 text-white px-8 py-4 rounded-lg hover:bg-navy-800 transition-all duration-200 font-semibold text-lg flex items-center justify-center group"
             >
-              Join Our Pilot Offer
+              Find Sponsored Talent
               <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
             </a>
             <a
-              href="#about"
+              href="#contact"
               className="border-2 border-gold-300 text-navy-700 px-8 py-4 rounded-lg hover:border-gold-400 hover:text-gold-400 transition-all duration-200 font-semibold text-lg"
             >
-              Learn More
+              Apply for Sponsor License
             </a>
           </div>
 
           <div className="grid md:grid-cols-3 gap-6 max-w-3xl mx-auto">
             <div className="flex items-center justify-center space-x-2 text-navy-700">
               <CheckCircle className="h-5 w-5 text-gold-400" />
-              <span className="font-medium">Automated Data Collection</span>
+              <span className="font-medium">Efficient Sponsor License Applications</span>
+            </div>
+            <div className="flex items-center justify-center space-x-2 text-navy-700">
+              <CheckCircle className="h-5 w-5 text-gold-400" />
+              <span className="font-medium">Global Talent Matching</span>
             </div>
             <div className="flex items-center justify-center space-x-2 text-navy-700">
               <CheckCircle className="h-5 w-5 text-gold-400" />
               <span className="font-medium">Real-time Compliance</span>
-            </div>
-            <div className="flex items-center justify-center space-x-2 text-navy-700">
-              <CheckCircle className="h-5 w-5 text-gold-400" />
-              <span className="font-medium">Seamless Submission</span>
             </div>
           </div>
         </div>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Users, Building2, Clock, Shield, UserCheck } from 'lucide-react';
+import { Users, Clock, Shield, UserCheck, ClipboardCheck } from 'lucide-react';
 
 const Products = () => {
   const products = [
@@ -16,16 +16,17 @@ const Products = () => {
       ]
     },
     {
-      icon: Building2,
-      title: 'FCA Compliance',
-      description: 'Comprehensive regulatory reporting for financial services, ensuring adherence to FCA requirements.',
-      status: 'Coming Soon',
+      icon: ClipboardCheck,
+      title: 'Apply for Sponsor License',
+      description: 'Step-by-step assistance and efficient management of your sponsor license application.',
+      status: 'Available Now',
       features: [
-        'Regulatory return automation',
-        'Risk assessment tools',
-        'Audit trail management',
-        'Real-time compliance monitoring'
-      ]
+        'Guided document preparation',
+        'Automated eligibility checks',
+        'Timeline and progress tracking',
+        'Expert support to reduce approval times'
+      ],
+      link: '#contact'
     },
     {
       icon: UserCheck,


### PR DESCRIPTION
## Summary
- Emphasize recruitment and sponsor license support in homepage hero with updated CTAs
- Replace FCA Compliance with "Apply for Sponsor License" product offering guided application assistance
- Add Recruitment navigation and "Start Recruiting" call-to-action in header

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e708cc25883338dd086798f569211