### PR TITLE
redirect recruitment links to contact form

### DIFF
--- a/src/components/Recruitment.tsx
+++ b/src/components/Recruitment.tsx
@@ -40,14 +40,14 @@ const Recruitment = () => {
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
               <a
-                href="#contact"
+                href="/#contact"
                 className="bg-navy-700 text-white px-8 py-4 rounded-lg hover:bg-navy-800 transition-all duration-200 font-semibold text-lg flex items-center justify-center group"
               >
                 Join as Employer
                 <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
               </a>
               <a
-                href="#contact"
+                href="/#contact"
                 className="border-2 border-gold-300 text-navy-700 px-8 py-4 rounded-lg hover:border-gold-400 hover:text-gold-400 transition-all duration-200 font-semibold text-lg"
               >
                 Find Sponsored Jobs


### PR DESCRIPTION
## Summary
- update employer and job seeker call-to-action links to open the home page contact form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689f991887508333b3b39073aaa9724f