### PR TITLE
refactor: simplify header brand styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo-picture_CHaM3jFR.png" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SoftHire - Automate Regulatory Reporting End-to-End</title>
     <meta name="description" content="SoftHire is a regtech platform that automates regulatory reporting from data collection to submission. Specializing in Immigration Compliance and FCA compliance solutions." />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Menu, X, CornerDownRight } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -8,11 +8,8 @@ const Header = () => {
     <header className="bg-navy-900 shadow-sm border-b border-gold-200 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          {/* Logo and Brand */}
-          <div className="flex items-center space-x-3">
-            <CornerDownRight className="h-8 w-8 text-gold-400" />
-            <span className="text-xl font-bold text-white">SoftHire</span>
-          </div>
+          {/* Brand */}
+          <span className="font-['DM Sans'] text-2xl font-bold text-gold-400">SoftHire</span>
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- remove arrow icon from header and display only SoftHire brand text
- style brand text with DM Sans, bold weight, gold color, and 2xl size
- load DM Sans font from Google Fonts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fbbbd0cec83338b190cb1510cab95