### PR TITLE
feat: add design tokens stylesheet

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,69 @@
+:root {
+  /* Brand colors */
+  --brand-primary: #4361ED;
+  --brand-primary-2: #4995EF;
+  --brand-royal: #3C5DEC;
+
+  /* Backgrounds & surfaces */
+  --bg-dark:   #021626;
+  --bg-light:  #F9F9F9;
+  --surface-1: #FFFFFF;
+  --surface-2: #0F2747;
+
+  /* Text */
+  --text-dark:  #0B1220;
+  --text-light: #FFFFFF;
+  --text-muted: #647290;
+
+  /* Borders & lines */
+  --line:       #9FA1A3;
+  --line-dark:  #374755;
+
+  /* Blues scale */
+  --blue-100: #AFCDF0;
+  --blue-200: #96B0ED;
+  --blue-600: #4995EF;
+  --blue-700: #4361ED;
+
+  /* Gradients */
+  --grad-brand: linear-gradient(180deg, #4995EF 0%, #4361ED 100%);
+
+  /* Radius & spacing */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-pill: 9999px;
+
+  --space-1: 8px;
+  --space-2: 12px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  --space-6: 48px;
+  --space-7: 64px;
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+
+  /* Type scale */
+  --fs-display: clamp(40px, 6vw, 64px);
+  --fs-h2:      clamp(28px, 3.5vw, 40px);
+  --fs-h3:      24px;
+  --fs-body:    16px;
+  --fs-small:   14px;
+  --lh-tight:   1.15;
+  --lh-normal:  1.5;
+
+  /* Shadows */
+  --shadow-1: 0 4px 16px rgba(2, 22, 38, 0.08);
+  --shadow-2: 0 8px 28px rgba(2, 22, 38, 0.12);
+}
+
+html, body {
+  background: var(--bg-light);
+  color: var(--text-dark);
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  line-height: var(--lh-normal);
+}


### PR DESCRIPTION
## Summary
- add global design token variables for colors, spacing, typography, and shadows
- include base html/body styles using the tokens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689feab10a848333980b1b4ce22702ae