### PR TITLE
feat: add design token and utility stylesheets

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,69 @@
+:root {
+  /* Brand colors */
+  --brand-primary: #4361ED;
+  --brand-primary-2: #4995EF;
+  --brand-royal: #3C5DEC;
+
+  /* Backgrounds & surfaces */
+  --bg-dark:   #021626;
+  --bg-light:  #F9F9F9;
+  --surface-1: #FFFFFF;
+  --surface-2: #0F2747;
+
+  /* Text */
+  --text-dark:  #0B1220;
+  --text-light: #FFFFFF;
+  --text-muted: #647290;
+
+  /* Borders & lines */
+  --line:       #9FA1A3;
+  --line-dark:  #374755;
+
+  /* Blues scale */
+  --blue-100: #AFCDF0;
+  --blue-200: #96B0ED;
+  --blue-600: #4995EF;
+  --blue-700: #4361ED;
+
+  /* Gradients */
+  --grad-brand: linear-gradient(180deg, #4995EF 0%, #4361ED 100%);
+
+  /* Radius & spacing */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-pill: 9999px;
+
+  --space-1: 8px;
+  --space-2: 12px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 32px;
+  --space-6: 48px;
+  --space-7: 64px;
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+
+  /* Type scale */
+  --fs-display: clamp(40px, 6vw, 64px);
+  --fs-h2:      clamp(28px, 3.5vw, 40px);
+  --fs-h3:      24px;
+  --fs-body:    16px;
+  --fs-small:   14px;
+  --lh-tight:   1.15;
+  --lh-normal:  1.5;
+
+  /* Shadows */
+  --shadow-1: 0 4px 16px rgba(2, 22, 38, 0.08);
+  --shadow-2: 0 8px 28px rgba(2, 22, 38, 0.12);
+}
+
+html, body {
+  background: var(--bg-light);
+  color: var(--text-dark);
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  line-height: var(--lh-normal);
+}

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -1,0 +1,38 @@
+/* Sections */
+.section--dark { background: var(--bg-dark); color: var(--text-light); }
+.section--brand { background: var(--grad-brand); color: var(--text-light); }
+
+/* Headings */
+.h-display { font-size: var(--fs-display); line-height: var(--lh-tight); font-weight: 800; }
+.h-2 { font-size: var(--fs-h2); line-height: var(--lh-tight); font-weight: 700; }
+
+/* Buttons */
+.btn {
+  display:inline-flex; align-items:center; justify-content:center;
+  gap:8px; padding:12px 20px; border-radius: var(--radius-pill);
+  border:1px solid transparent; font-weight:600; text-decoration:none;
+}
+.btn--primary { background: var(--brand-primary); color: var(--text-light); }
+.btn--primary:hover { background: var(--brand-royal); }
+.btn--ghost { background: transparent; border-color: var(--line); color: var(--text-dark); }
+.btn--ghost:hover { border-color: var(--brand-primary); color: var(--brand-primary); }
+
+/* Cards */
+.card {
+  background: var(--surface-1);
+  border:1px solid rgba(0,0,0,0.06);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-1);
+  padding: var(--space-4);
+}
+
+/* Navbar */
+.navbar {
+  background: #fff; border-bottom:1px solid rgba(0,0,0,0.05);
+}
+.navbar a { color: var(--text-dark); }
+.navbar a.cta { background: var(--brand-primary); color: var(--text-light); border-radius: var(--radius-pill); padding:10px 16px; }
+
+/* Footer */
+.footer { background: var(--bg-dark); color: var(--text-light); }
+.footer a { color: var(--blue-200); }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="stylesheet" href="/css/tokens.css">
+    <link rel="stylesheet" href="/css/utilities.css">
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -51,7 +51,7 @@ const About = () => {
           ))}
         </div>
 
-        <div className="bg-white dark:bg-primary-800 rounded-xl p-8 md:p-12 shadow-sm border border-accent-200 dark:border-primary-700">
+        <div className="card bg-white dark:bg-primary-800 rounded-xl p-8 md:p-12 shadow-sm border border-accent-200 dark:border-primary-700">
           <div className="max-w-4xl mx-auto text-center">
             <h3 className="text-2xl md:text-3xl font-bold text-primary-900 dark:text-primary-100 mb-6">
               Why Choose SoftHire?

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { Linkedin, Twitter, Mail } from 'lucide-react';
 
 const Footer = () => {
   return (
-    <footer className="bg-primary-900 dark:bg-primary-950 text-white py-16">
+    <footer className="footer bg-primary-900 dark:bg-primary-950 text-white py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid md:grid-cols-4 gap-8">
           {/* Company Info */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ const Header = () => {
           <span className="font-sans text-2xl font-bold text-accent-400">SoftHire</span>
 
           {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center space-x-8">
+          <nav className="navbar hidden md:flex items-center space-x-8">
             <a href="#products" className="text-white hover:text-accent-400 transition-colors font-medium">
               Products
             </a>
@@ -25,7 +25,7 @@ const Header = () => {
             <a href="#contact" className="text-white hover:text-accent-400 transition-colors font-medium">
               Contact
             </a>
-            <a href="/recruitment" className="bg-primary-700 text-white px-6 py-2 rounded-lg hover:bg-primary-800 transition-colors font-medium">
+            <a href="/recruitment" className="cta bg-primary-700 text-white px-6 py-2 rounded-lg hover:bg-primary-800 transition-colors font-medium">
               Start Recruiting
             </a>
           </nav>
@@ -55,7 +55,7 @@ const Header = () => {
               <a href="#contact" className="text-white hover:text-accent-400 transition-colors font-medium">
                 Contact
               </a>
-              <a href="/recruitment" className="bg-primary-700 text-white px-6 py-2 rounded-lg hover:bg-primary-800 transition-colors font-medium w-fit">
+              <a href="/recruitment" className="cta bg-primary-700 text-white px-6 py-2 rounded-lg hover:bg-primary-800 transition-colors font-medium w-fit">
                 Start Recruiting
               </a>
             </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,10 +3,10 @@ import { ArrowRight, CheckCircle } from 'lucide-react';
 
 const Hero = () => {
   return (
-    <section className="bg-gradient-to-br from-accent-100 via-white to-primary-100 dark:from-primary-800 dark:via-primary-900 dark:to-primary-950 py-24 md:py-32">
+    <section className="section bg-gradient-to-br from-accent-100 via-white to-primary-100 dark:from-primary-800 dark:via-primary-900 dark:to-primary-950 py-24 md:py-32">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-6xl font-bold text-primary-900 dark:text-primary-100 mb-6 leading-tight">
+          <h1 className="h-display text-primary-900 dark:text-primary-100 mb-6">
             Simplify <br className="md:hidden" />
             Sponsorship <span className="text-accent-500">Compliance</span> &
             Recruitment
@@ -20,14 +20,14 @@ const Hero = () => {
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <a
               href="/recruitment"
-              className="bg-primary-700 dark:bg-primary-600 text-white px-8 py-4 rounded-xl hover:bg-primary-800 dark:hover:bg-primary-500 transition-all duration-200 font-semibold text-lg flex items-center justify-center group"
+              className="btn btn--primary bg-primary-700 dark:bg-primary-600 text-white px-8 py-4 rounded-xl hover:bg-primary-800 dark:hover:bg-primary-500 transition-all duration-200 font-semibold text-lg flex items-center justify-center group"
             >
               Find Sponsored Talent
               <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
             </a>
             <a
               href="#contact"
-              className="border-2 border-accent-300 dark:border-primary-700 text-primary-700 dark:text-primary-200 px-8 py-4 rounded-xl hover:border-accent-400 dark:hover:border-primary-500 hover:text-accent-400 transition-all duration-200 font-semibold text-lg"
+              className="btn btn--ghost border-2 border-accent-300 dark:border-primary-700 text-primary-700 dark:text-primary-200 px-8 py-4 rounded-xl hover:border-accent-400 dark:hover:border-primary-500 hover:text-accent-400 transition-all duration-200 font-semibold text-lg"
             >
               Apply for Sponsor License
             </a>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -60,7 +60,7 @@ const Products = () => {
           {products.map((product, index) => (
             <div
               key={index}
-              className="bg-accent-100 dark:bg-primary-800 rounded-xl p-8 hover:shadow-lg transition-shadow duration-300 border border-accent-200 dark:border-primary-700 flex flex-col"
+              className="card bg-accent-100 dark:bg-primary-800 rounded-xl p-8 hover:shadow-lg transition-shadow duration-300 border border-accent-200 dark:border-primary-700 flex flex-col"
             >
               <div className="flex items-center mb-6">
                 <div className="bg-primary-200 dark:bg-primary-700 p-3 rounded-lg mr-4">


### PR DESCRIPTION
## Summary
- add global design token variables for colors, spacing, typography, and shadows
- include base html/body styles using the tokens
- link tokens stylesheet in the global layout
- provide shared utility classes for sections, headings, buttons, cards, navbar, and footer
- ensure utilities stylesheet loads immediately after tokens in the global layout
- replace hardcoded white text in utility styles with `var(--text-light)`
- tag navigation, hero, card, and footer markup with corresponding utility classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689feab10a848333980b1b4ce22702ae