### PR TITLE
Refine hero section styling and CTA layout

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,31 +3,31 @@ import { ArrowRight, CheckCircle } from 'lucide-react';
 
 const Hero = () => {
   return (
-    <section className="section bg-gradient-to-br from-accent-100 via-white to-primary-100 dark:from-primary-800 dark:via-primary-900 dark:to-primary-950 py-24 md:py-32">
+    <section className="section bg-[color:var(--bg-dark)] py-24 md:py-32">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center max-w-4xl mx-auto">
-          <h1 className="h-display text-primary-900 dark:text-primary-100 mb-6">
+          <h1 className="h-display text-white mb-6 text-center">
             Simplify <br className="md:hidden" />
             Sponsorship <span className="text-accent-500">Compliance</span> &
             Recruitment
           </h1>
 
-          <p className="text-xl md:text-2xl text-primary-600 dark:text-primary-200 mb-8 leading-relaxed">
+          <p className="text-xl md:text-2xl text-blue-100 mb-8 leading-relaxed text-center">
             SoftHire streamlines sponsor license applications and connects you with qualified global talent,
             helping businesses navigate compliance and recruitment with confidence.
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+          <div className="hero-cta justify-center">
             <a
               href="/recruitment"
-              className="btn btn--primary bg-primary-700 dark:bg-primary-600 text-white px-8 py-4 rounded-xl hover:bg-primary-800 dark:hover:bg-primary-500 transition-all duration-200 font-semibold text-lg flex items-center justify-center group"
+              className="btn btn--primary"
             >
               Find Sponsored Talent
               <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
             </a>
             <a
               href="#contact"
-              className="btn btn--ghost border-2 border-accent-300 dark:border-primary-700 text-primary-700 dark:text-primary-200 px-8 py-4 rounded-xl hover:border-accent-400 dark:hover:border-primary-500 hover:text-accent-400 transition-all duration-200 font-semibold text-lg"
+              className="btn btn--ghost"
             >
               Apply for Sponsor License
             </a>


### PR DESCRIPTION
## Summary
- simplify hero background and heading styles for a unified dark theme
- center headline and subhead with updated colour palette
- streamline call-to-action buttons with new wrapper and minimal classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a099230e90833395d5a61aa9741846