### PR TITLE
Add card styling to recruitment and contact cards

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -72,7 +72,7 @@ const Contact = () => {
           <div>
             <h3 className="text-2xl font-bold text-navy-900 mb-8">Let's Connect</h3>
 
-            <div className="mt-12 p-6 bg-gold-100 rounded-xl border border-gold-300">
+            <div className="mt-12 card card--tight p-6 bg-gold-100 rounded-xl border border-gold-300">
               <h4 className="font-semibold text-navy-900 mb-3">Stay Updated</h4>
               <p className="text-navy-600 mb-4">
                 Be the first to know when our products launch. Join our mailing list for updates 

--- a/src/components/Recruitment.tsx
+++ b/src/components/Recruitment.tsx
@@ -88,7 +88,7 @@ const Recruitment = () => {
             {targetIndustries.map((industry, index) => (
               <div
                 key={index}
-                className="bg-accent-100 dark:bg-primary-800 rounded-xl p-8 hover:shadow-lg transition-shadow duration-300 border border-accent-200 dark:border-primary-700"
+                className="card card--elevated bg-accent-100 dark:bg-primary-800 rounded-xl p-8 hover:shadow-lg transition-shadow duration-300 border border-accent-200 dark:border-primary-700"
               >
                 <div className="flex items-center mb-6">
                   <div className="bg-primary-200 dark:bg-primary-700 p-3 rounded-lg mr-4">
@@ -135,7 +135,7 @@ const Recruitment = () => {
 
           <div className="grid md:grid-cols-2 gap-12">
             {/* For Employers */}
-            <div className="bg-white dark:bg-primary-700 rounded-xl p-8 shadow-sm border border-accent-200 dark:border-primary-600">
+            <div className="card card--tight bg-white dark:bg-primary-700 rounded-xl p-8 shadow-sm border border-accent-200 dark:border-primary-600">
               <div className="flex items-center mb-6">
                 <Building2 className="h-8 w-8 text-primary-700 dark:text-primary-200 mr-3" />
                 <h3 className="text-2xl font-bold text-primary-900 dark:text-primary-100">For Employers</h3>
@@ -161,7 +161,7 @@ const Recruitment = () => {
             </div>
 
             {/* For Candidates */}
-            <div className="bg-white dark:bg-primary-700 rounded-xl p-8 shadow-sm border border-accent-200 dark:border-primary-600">
+            <div className="card card--tight bg-white dark:bg-primary-700 rounded-xl p-8 shadow-sm border border-accent-200 dark:border-primary-600">
               <div className="flex items-center mb-6">
                 <Users className="h-8 w-8 text-primary-700 dark:text-primary-200 mr-3" />
                 <h3 className="text-2xl font-bold text-primary-900 dark:text-primary-100">For Candidates</h3>


### PR DESCRIPTION
## Summary
- elevate target industry cards with `card card--elevated`
- tighten platform feature cards and contact subscribe card with `card card--tight`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a09bd4e9588333b4181cd0b7702cdf