### PR TITLE
Remove Recruitment feature and update CTAs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import Products from './components/Products';
 import About from './components/About';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
-import Recruitment from './components/Recruitment';
 import CandidatesForm2 from './components/CandidatesForm2';
 
 const HomePage = () => (
@@ -26,7 +25,6 @@ function App() {
         <Header />
         <Routes>
           <Route path="/" element={<HomePage />} />
-          <Route path="/recruitment" element={<Recruitment />} />
           <Route path="/candidates" element={<CandidatesForm2 />} />
         </Routes>
         <Footer />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -78,8 +78,8 @@ const About = () => {
               <p className="text-lg text-charcoal-700 leading-relaxed">
                 Built by entrepreneurs with experience in <span className="font-semibold text-mint-600">law, compliance, and technology</span>, SoftHire was
                 created to solve a pressing problem: UK companies face skill shortages but struggle with the
-                complexity of immigration compliance. Our platform combines automation, legal expertise,
-                and recruitment support so businesses can focus on <span className="font-semibold text-lavender-600">growth — not red tape</span>.
+                complexity of immigration compliance. Our platform combines automation and legal expertise
+                so businesses can focus on <span className="font-semibold text-lavender-600">growth — not red tape</span>.
               </p>
             </div>
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -84,11 +84,6 @@ const Footer = () => {
                   Sponsor License Application
                 </a>
               </li>
-              <li>
-                <a href="#" className="text-blue-200 hover:text-white transition-colors duration-300 hover:translate-x-1 transform inline-block">
-                  Recruitment Platform
-                </a>
-              </li>
             </ul>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,17 +43,11 @@ const Header = () => {
             <a href="/#products" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium">
               Products
             </a>
-            <a href="/recruitment" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium">
-              Recruitment
-            </a>
             <a href="/#about" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium">
               About
             </a>
             <a href="#contact" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium">
               Contact
-            </a>
-            <a href="/recruitment" className="btn btn--primary text-white">
-              <span className="hidden md:inline text-white">Start Recruiting</span>
             </a>
           </nav>
 
@@ -73,20 +67,12 @@ const Header = () => {
               <a href="/#products" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium px-4 py-2">
                 Products
               </a>
-              <a href="/recruitment" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium px-4 py-2">
-                Recruitment
-              </a>
               <a href="/#about" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium px-4 py-2">
                 About
               </a>
               <a href="#contact" className="text-charcoal-800 hover:text-blue-500 transition-colors font-medium px-4 py-2">
                 Contact
               </a>
-              <div className="px-4">
-                <a href="/recruitment" className="btn btn--primary w-full ">
-                  <span className="text-white">Start Recruiting</span>
-                </a>
-              </div>
             </div>
           </div>
         )}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -50,22 +50,22 @@ const Hero = () => {
 
           <p className="text-xl md:text-2xl text-blue-100 mb-8 leading-relaxed text-center max-w-3xl mx-auto hidden">
             SoftHire streamlines sponsor license applications and connects you with qualified global talent,
-            helping businesses navigate compliance and recruitment with confidence.
+            helping businesses navigate compliance with confidence.
           </p>
 
           <div className="hero-cta justify-center mb-12">
             <a
-              href="/recruitment"
+              href="/candidates"
               className="btn btn--primary group"
             >
-              For Companies
+              For Candidates
               <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
             </a>
             <a
-              href="/candidates"
+              href="#contact"
               className="btn text-white border-2 border-blue-300 hover:bg-blue-500/10 hover:border-blue-400 transition-all duration-300"
             >
-              For Candidates
+              Contact Us
             </a>
           </div>
 

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,4 +1,4 @@
-import { Users, Clock, Shield, UserCheck, ClipboardCheck } from 'lucide-react';
+import { Users, Clock, Shield, ClipboardCheck } from 'lucide-react';
 
 const Products = () => {
   const products = [
@@ -33,22 +33,6 @@ const Products = () => {
       ],
       link: '#contact',
       accentColor: 'mint'
-    },
-    {
-      icon: UserCheck,
-      title: 'Sponsored Recruitment Platform',
-      description: 'A platform to connect talented candidates with UK Sponsor Licence holders:',
-      status: 'Available Now',
-      features: [
-        'Vetted candidates from around the world',
-        'Ability to directly connect with candidates on online platform',
-        'Recruiter assistance on request',
-        'Candidates sorted by relevance',
-        'Assistance with post-offer next steps',
-        'Employee Visa assistance'
-      ],
-      link: '#contact',
-      accentColor: 'aqua'
     }
   ];
 
@@ -98,7 +82,7 @@ const Products = () => {
           </p>
         </div>
 
-        <div className="grid lg:grid-cols-3 gap-8">
+        <div className="grid lg:grid-cols-2 gap-8 max-w-5xl mx-auto">
           {products.map((product, index) => (
             <div
               key={index}


### PR DESCRIPTION
Remove the Recruitment product/flow and adjust UI/links accordingly. Deleted Recruitment import and route in App.tsx; removed Recruitment nav links and CTA buttons from Header and Footer; dropped the Sponsored Recruitment product entry and its icon import from Products.tsx and adjusted the product grid layout. Update Hero CTAs to point to candidates and contact, and simplify About copy to remove recruitment-specific phrasing. These changes streamline the site by deprecating the recruitment offering and updating navigation and content to match.