### PR TITLE
Add sector pages, nav, and hash scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,11 @@
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Syne:wght@700;800&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Syne:wght@700;800&family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
   <!-- Site styles LAST -->
   <link rel="stylesheet" href="/css/style.css" />
   <!-- icon -->
-  <link rel="icon" type="image/x-icon" href="/public/logo22.svg" />
+  <link rel="icon" type="image/x-icon" href="/public/logo.svg" />
 </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,11 @@ import About from './components/About';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
 import CandidatesForm2 from './components/CandidatesForm2';
+import ImmigrationCompliancePage from './components/pages/ImmigrationCompliancePage';
+import SponsorLicenceCareHomesPage from './components/pages/SponsorLicenceCareHomesPage';
+import SponsorLicenceRestaurantsPage from './components/pages/SponsorLicenceRestaurantsPage';
+import SponsorLicenceTechStartupsPage from './components/pages/SponsorLicenceTechStartupsPage';
+import SponsorLicenceUniversitiesPage from './components/pages/SponsorLicenceUniversitiesPage';
 import { trackPageView, trackScrollDepth } from './lib/analytics';
 
 // ── Page-view tracker (fires on every route change) ───────────────────────────
@@ -40,6 +45,26 @@ function ScrollDepthTracker() {
   return null;
 }
 
+// ── Hash scroll handler (scrolls to hash target after SPA navigation) ────────
+function HashScrollHandler() {
+  const location = useLocation();
+  useEffect(() => {
+    if (location.hash) {
+      const id = location.hash.slice(1);
+      const scrollToEl = () => {
+        const el = document.getElementById(id);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      };
+      scrollToEl();
+      const t = setTimeout(scrollToEl, 80);
+      return () => clearTimeout(t);
+    } else {
+      window.scrollTo(0, 0);
+    }
+  }, [location.pathname, location.hash]);
+  return null;
+}
+
 const HomePage = () => (
   <>
     <Hero />
@@ -55,11 +80,17 @@ function App() {
     <Router>
       <PageViewTracker />
       <ScrollDepthTracker />
+      <HashScrollHandler />
       <div className="min-h-screen" style={{ background: '#0B1736' }}>
         <Header />
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/candidates" element={<CandidatesForm2 />} />
+          <Route path="/immigration-compliance" element={<ImmigrationCompliancePage />} />
+          <Route path="/sponsor-licence-care-homes" element={<SponsorLicenceCareHomesPage />} />
+          <Route path="/sponsor-licence-restaurants" element={<SponsorLicenceRestaurantsPage />} />
+          <Route path="/sponsor-licence-tech-startups" element={<SponsorLicenceTechStartupsPage />} />
+          <Route path="/sponsor-licence-universities" element={<SponsorLicenceUniversitiesPage />} />
         </Routes>
         <Footer />
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 ﻿import { Linkedin, Twitter, Mail } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { trackFooterClick, trackContactLinkClick } from '../lib/analytics';
 
 const Footer = () => {
@@ -12,7 +13,7 @@ const Footer = () => {
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10 py-16">
-        <div className="grid md:grid-cols-4 gap-10 mb-14">
+        <div className="grid md:grid-cols-5 gap-10 mb-14">
           {/* Brand */}
           <div className="md:col-span-1">
             <div className="flex items-center mb-4">
@@ -62,6 +63,24 @@ const Footer = () => {
               ].map((s) => (
                 <li key={s}>
                   <a href="#visas" className="text-white/50 hover:text-amber-400 text-sm transition-colors duration-200" onClick={() => trackFooterClick(`service_${s.toLowerCase().replace(/ /g, '_')}`)}>{s}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          {/* Sectors */}
+          <nav aria-label="Sectors">
+            <h3 className="text-xs font-bold uppercase tracking-widest text-white mb-4">Sectors</h3>
+            <ul className="flex flex-col gap-3">
+              {[
+                { to: '/sponsor-licence-care-homes', label: 'Care Homes' },
+                { to: '/sponsor-licence-restaurants', label: 'Restaurants & Hospitality' },
+                { to: '/sponsor-licence-tech-startups', label: 'Tech Startups' },
+                { to: '/sponsor-licence-universities', label: 'Universities' },
+                { to: '/immigration-compliance', label: 'Recruitment Agencies' },
+              ].map(({ to, label }) => (
+                <li key={to}>
+                  <Link to={to} className="text-white/50 hover:text-amber-400 text-sm transition-colors duration-200" onClick={() => trackFooterClick(`sector_${label.toLowerCase().replace(/ /g, '_')}`)}>{label}</Link>
                 </li>
               ))}
             </ul>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,20 @@
 import { useState, useEffect } from 'react';
-import { Menu, X } from 'lucide-react';
+import { Menu, X, ChevronDown } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { trackNavClick, trackCTAClick } from '../lib/analytics';
+
+const SECTOR_LINKS = [
+  { to: '/sponsor-licence-care-homes', label: 'Care Homes' },
+  { to: '/sponsor-licence-restaurants', label: 'Restaurants & Hospitality' },
+  { to: '/sponsor-licence-tech-startups', label: 'Tech Startups' },
+  { to: '/sponsor-licence-universities', label: 'Universities' },
+  { to: '/immigration-compliance', label: 'Recruitment Agencies' },
+];
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [sectorsOpen, setSectorsOpen] = useState(false);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 40);
@@ -37,6 +47,31 @@ const Header = () => {
             <a href="/#visas" className="text-white/70 hover:text-white transition-colors text-sm font-medium uppercase tracking-wider" onClick={() => trackNavClick('visa_types')}>
               Visa Types
             </a>
+            {/* Sectors dropdown */}
+            <div className="relative" onMouseEnter={() => setSectorsOpen(true)} onMouseLeave={() => setSectorsOpen(false)}>
+              <button
+                className="flex items-center gap-1 text-white/70 hover:text-white transition-colors text-sm font-medium uppercase tracking-wider bg-transparent border-none cursor-pointer"
+                onClick={() => setSectorsOpen((v) => !v)}
+                aria-haspopup="true"
+                aria-expanded={sectorsOpen}
+              >
+                Sectors <ChevronDown className={`h-3.5 w-3.5 transition-transform ${sectorsOpen ? 'rotate-180' : ''}`} />
+              </button>
+              {sectorsOpen && (
+                <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 w-56 bg-navy-900/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-xl overflow-hidden z-50">
+                  {SECTOR_LINKS.map(({ to, label }) => (
+                    <Link
+                      key={to}
+                      to={to}
+                      className="block px-4 py-3 text-sm text-white/70 hover:text-amber-400 hover:bg-white/5 transition-colors"
+                      onClick={() => { setSectorsOpen(false); trackNavClick(`sector_${label.toLowerCase().replace(/ /g, '_')}`); }}
+                    >
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
             <a href="/#about" className="text-white/70 hover:text-white transition-colors text-sm font-medium uppercase tracking-wider" onClick={() => trackNavClick('about')}>
               About
             </a>
@@ -94,6 +129,19 @@ const Header = () => {
               <a href="/#visas" className="text-white/70 hover:text-white transition-colors font-medium px-4 py-3 rounded-lg hover:bg-white/5" onClick={() => { setIsMenuOpen(false); trackNavClick('mobile_visa_types'); }}>
                 Visa Types
               </a>
+              <div className="px-4 py-2">
+                <p className="text-xs font-bold uppercase tracking-widest text-white/30 mb-1">Sectors</p>
+                {SECTOR_LINKS.map(({ to, label }) => (
+                  <Link
+                    key={to}
+                    to={to}
+                    className="block text-white/60 hover:text-amber-400 transition-colors text-sm py-2 pl-2"
+                    onClick={() => { setIsMenuOpen(false); trackNavClick(`mobile_sector_${label.toLowerCase().replace(/ /g, '_')}`); }}
+                  >
+                    {label}
+                  </Link>
+                ))}
+              </div>
               <a href="/#about" className="text-white/70 hover:text-white transition-colors font-medium px-4 py-3 rounded-lg hover:bg-white/5" onClick={() => { setIsMenuOpen(false); trackNavClick('mobile_about'); }}>
                 About
               </a>

--- a/src/components/pages/ImmigrationCompliancePage.tsx
+++ b/src/components/pages/ImmigrationCompliancePage.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { trackCTAClick, trackFAQOpen, trackSectorLinkClick, trackAnchorClick } from '../../lib/analytics';
+
+const C = {
+  navy: '#0B1736',
+  navyMid: '#132048',
+  gold: '#C9A84C',
+  cream: '#F5F1EA',
+  textMuted: '#8a95b0',
+  border: 'rgba(201,168,76,0.2)',
+} as const;
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em',
+  textTransform: 'uppercase', color: C.gold, marginBottom: '16px',
+};
+const h2Style: React.CSSProperties = {
+  fontFamily: "'Cormorant Garamond', serif",
+  fontSize: 'clamp(1.8rem, 3.5vw, 2.8rem)',
+  fontWeight: 700, color: C.cream, lineHeight: 1.2, marginBottom: '20px',
+};
+const h3Style: React.CSSProperties = {
+  fontSize: '1.1rem', fontWeight: 600, color: C.cream, marginBottom: '8px',
+};
+const pStyle: React.CSSProperties = { color: C.textMuted, marginBottom: '16px' };
+const cardStyle: React.CSSProperties = {
+  background: C.navy, border: `1px solid ${C.border}`,
+  borderRadius: '8px', padding: '32px 28px',
+};
+
+const FAQS = [
+  {
+    q: 'Are recruitment agencies liable for right to work breaches?',
+    a: 'Yes. Where an agency supplies workers to a client, the agency typically bears primary responsibility for right to work checks at the point of placement. A civil penalty of up to £60,000 per illegal worker applies where checks were not conducted correctly, regardless of what the client represents.',
+  },
+  {
+    q: 'What right to work checks must recruitment agencies carry out?',
+    a: 'Before placing a worker, agencies must confirm right to work in the UK using one of three methods: manual document checks (using prescribed lists A and B documents), online checks via the Home Office Employer Checking Service share code, or digital checks via a certified Identity Service Provider (IDSP) for British and Irish citizens.',
+  },
+  {
+    q: 'Can a recruitment agency hold a sponsor licence?',
+    a: "Yes, but with restrictions. Agencies can hold a Worker sponsor licence to employ their own staff directly. However, agencies cannot use their own licence to sponsor workers who will be supplied to end-clients — the end client must hold the relevant licence. Attempting to circumvent this is a serious breach of sponsorship duties.",
+  },
+  {
+    q: 'What digital right to work tools are acceptable?',
+    a: 'Since April 2022, employers and agencies can use certified Identity Service Providers (IDSPs) for digital right to work checks on British and Irish citizens using their passport. For other nationalities, online checks using the Home Office share code system are required. Manual document checks remain valid across all nationalities.',
+  },
+  {
+    q: "What should an agency do if a placed worker's visa expires?",
+    a: "If you become aware that a worker's leave to remain has expired or will expire, you must stop supplying them and check their status immediately. If there is a statutory excuse from a previous compliant check, this provides a defence — but agencies should have follow-up monitoring processes in place for workers on time-limited visas.",
+  },
+  {
+    q: 'Does right to work compliance apply to contractors and self-employed individuals?',
+    a: 'Yes. Where an agency engages or supplies individuals under any contractual arrangement, they must confirm that person has the right to work in the UK. The structure of the engagement does not remove the compliance obligation.',
+  },
+];
+
+export default function ImmigrationCompliancePage() {
+  useEffect(() => {
+    document.title =
+      'Immigration Compliance for Recruitment Agencies | Right to Work & Sponsor Licence | SoftHire';
+  }, []);
+  const [openFAQ, setOpenFAQ] = useState<number | null>(null);
+
+  return (
+    <div style={{ background: C.navy, color: C.cream, lineHeight: 1.7, fontSize: '16px', fontFamily: "'DM Sans', sans-serif" }}>
+
+      {/* ── Hero ── */}
+      <section style={{ padding: '100px 5% 80px', maxWidth: '1100px', margin: '0 auto' }}>
+        <div style={{ display: 'inline-block', border: `1px solid ${C.gold}`, color: C.gold, fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '5px 14px', borderRadius: '2px', marginBottom: '28px' }}>
+          Recruitment &amp; Staffing · Compliance
+        </div>
+        <h1 style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: 'clamp(2.4rem, 5vw, 3.8rem)', fontWeight: 700, lineHeight: 1.15, color: C.cream, maxWidth: '820px', marginBottom: '24px' }}>
+          Immigration Compliance for<br />
+          <em style={{ color: C.gold, fontStyle: 'italic' }}>Recruitment Agencies</em>
+        </h1>
+        <p style={{ fontSize: '1.1rem', color: C.textMuted, maxWidth: '600px', marginBottom: '40px', fontWeight: 300 }}>
+          Placing the wrong candidate — or missing a right to work check — can cost your agency up to
+          £60,000 per worker. SoftHire keeps your compliance infrastructure airtight.
+        </p>
+        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <Link
+            to={{ pathname: '/', hash: '#contact' }}
+            style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+            onClick={() => trackCTAClick('book_consultation', 'hero_immigration_compliance')}
+          >
+            Book a Free Consultation
+          </Link>
+          <a href="#services" style={{ border: `1px solid ${C.border}`, color: C.cream, padding: '14px 28px', borderRadius: '4px', textDecoration: 'none', fontSize: '0.95rem' }} onClick={() => trackAnchorClick('see_services', 'immigration_compliance')}>
+            See our services →
+          </a>
+        </div>
+      </section>
+
+      {/* ── Trust Bar ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '24px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'flex', gap: '40px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {['IAA-Regulated', '97% Success Rate', 'Right to Work Compliance', 'Candidate Visa Screening', 'Fixed-Fee'].map((label) => (
+            <div key={label} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <span style={{ color: C.gold }}>✦</span>
+              <span style={{ fontSize: '0.85rem', fontWeight: 500, color: C.cream }}>{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Risk / The Stakes ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>The Stakes</div>
+          <h2 style={h2Style}>Immigration non-compliance is an existential risk for agencies</h2>
+          <p style={{ ...pStyle, maxWidth: '680px' }}>
+            Recruitment agencies occupy a unique and exposed position in the immigration compliance
+            landscape. As the entity placing workers, you carry primary legal responsibility —
+            regardless of what the client told you.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '20px', marginTop: '40px' }}>
+            {[
+              { stat: '£60,000', desc: 'Maximum civil penalty per illegal worker where right to work checks were not carried out correctly.' },
+              { stat: '5 years', desc: 'Maximum custodial sentence for knowing facilitation of illegal working (criminal offence for directors).' },
+              { stat: 'Public', desc: 'Employers receiving civil penalties are published on the Home Office public register — damaging to client relationships.' },
+              { stat: 'Licence', desc: 'Agencies holding Gangmasters & Labour Abuse Authority (GLAA) licences risk revocation for immigration breaches.' },
+            ].map(({ stat, desc }) => (
+              <div key={stat} style={{ background: 'rgba(201,168,76,0.05)', border: '1px solid rgba(201,168,76,0.3)', borderRadius: '8px', padding: '24px' }}>
+                <div style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: '1.8rem', fontWeight: 700, color: C.gold, marginBottom: '8px' }}>{stat}</div>
+                <p style={{ color: C.textMuted, fontSize: '0.9rem', margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Services ── */}
+      <section id="services" style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Services</div>
+          <h2 style={h2Style}>What SoftHire does for recruitment agencies</h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginTop: '48px' }}>
+            {[
+              { icon: '✅', title: 'Right to Work Compliance Audit', desc: 'A full review of your current right to work check processes — identifying gaps, non-compliant documentation and systemic risks before they become penalties.' },
+              { icon: '🔎', title: 'Candidate Immigration Screening', desc: "Pre-placement screening to determine each candidate's immigration status, visa conditions and right to work — so your consultants know the position before they make an introduction." },
+              { icon: '📄', title: 'Compliance Policy & Process Design', desc: "Building right to work procedures, training materials and internal escalation frameworks tailored to your agency's size and sector specialisms." },
+              { icon: '🏢', title: 'Sponsor Licence for Agency Own-Staff', desc: 'Where your agency directly employs international staff, we manage your Worker sponsor licence application, CoS allocation and ongoing compliance.' },
+              { icon: '🤝', title: 'Client Immigration Advisory', desc: 'Supporting your clients with sponsor licence applications and compliance — delivered as a white-label or co-branded service under your agency brand.' },
+              { icon: '🧾', title: 'Digital Right to Work Check Guidance', desc: 'Advising on compliant use of Identity Service Providers (IDSPs) and the Home Office online checking service for all candidate categories.' },
+            ].map(({ icon, title, desc }) => (
+              <div key={title} style={cardStyle}>
+                <div style={{ fontSize: '1.8rem', marginBottom: '16px' }}>{icon}</div>
+                <h3 style={h3Style}>{title}</h3>
+                <p style={{ ...pStyle, margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Who We Serve ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '60px' }}>
+            <div>
+              <div style={sectionLabel}>Who We Work With</div>
+              <h2 style={h2Style}>Built for agencies of every size and sector</h2>
+              <p style={pStyle}>
+                Whether you're a boutique technology recruiter or a large-scale industrial staffing
+                firm, immigration compliance touches every placement you make. SoftHire adapts to
+                your volume and sector.
+              </p>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {[
+                  'Technology and engineering recruiters',
+                  'Healthcare and nursing agencies',
+                  'Construction and trades staffing firms',
+                  'Hospitality and catering recruiters',
+                  'Executive search firms',
+                  'Industrial and logistics staffing companies',
+                  'GLAA-licensed labour providers',
+                ].map((item) => (
+                  <li key={item} style={{ display: 'flex', gap: '12px', alignItems: 'flex-start', padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.05)', color: C.cream, fontSize: '0.95rem' }}>
+                    <span style={{ color: C.gold, flexShrink: 0, marginTop: '2px' }}>✦</span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <div style={sectionLabel}>How We Work</div>
+              <h2 style={h2Style}>Retained, project-based or on-demand</h2>
+              <p style={pStyle}>SoftHire works with agencies on whatever model fits your needs:</p>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {[
+                  { label: 'Retained:', desc: 'Ongoing compliance support, candidate screening volume and policy maintenance on a monthly retainer' },
+                  { label: 'Project-based:', desc: 'One-off compliance audit, policy redesign or sponsor licence application' },
+                  { label: 'On-demand:', desc: 'Complex individual candidate queries, urgent visa status checks or time-sensitive client advisory' },
+                ].map(({ label, desc }) => (
+                  <li key={label} style={{ display: 'flex', gap: '12px', alignItems: 'flex-start', padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.05)', color: C.cream, fontSize: '0.95rem' }}>
+                    <span style={{ color: C.gold, flexShrink: 0, marginTop: '2px' }}>✦</span>
+                    <span><strong style={{ color: C.cream }}>{label}</strong> {desc}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>FAQ</div>
+          <h2 style={h2Style}>Immigration compliance questions for agencies</h2>
+          <div>
+            {FAQS.map((faq, i) => (
+              <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+                <button
+                  onClick={() => { if (openFAQ !== i) trackFAQOpen(faq.q, 'immigration_compliance'); setOpenFAQ(openFAQ === i ? null : i); }}
+                  style={{ width: '100%', textAlign: 'left', padding: '24px 0', background: 'none', border: 'none', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px' }}
+                  aria-expanded={openFAQ === i}
+                >
+                  <span style={{ fontWeight: 600, color: C.cream, fontSize: '1rem' }}>{faq.q}</span>
+                  <span style={{ color: C.gold, flexShrink: 0, fontSize: '1.4rem', lineHeight: 1 }}>{openFAQ === i ? '−' : '+'}</span>
+                </button>
+                {openFAQ === i && (
+                  <div style={{ paddingBottom: '24px', color: C.textMuted, fontSize: '0.95rem', lineHeight: 1.7 }}>{faq.a}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA Band ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '80px 5%', textAlign: 'center' }}>
+        <div style={{ ...sectionLabel, textAlign: 'center' }}>Get Started</div>
+        <h2 style={{ ...h2Style, textAlign: 'center' }}>
+          Don't let a compliance gap cost you a client — or your licence.
+        </h2>
+        <p style={{ color: C.textMuted, marginBottom: '36px', maxWidth: '520px', marginLeft: 'auto', marginRight: 'auto' }}>
+          Book a free consultation. We'll review your current processes and show you exactly where
+          your risk exposure is — in plain English, with a clear plan to fix it.
+        </p>
+        <Link
+          to={{ pathname: '/', hash: '#contact' }}
+          style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+          onClick={() => trackCTAClick('book_consultation', 'cta_band_immigration_compliance')}
+        >
+          Book Free Consultation
+        </Link>
+      </div>
+
+      {/* ── Related Links ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Also on SoftHire</div>
+          <h2 style={h2Style}>Other sponsor licence services</h2>
+          <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+            {[
+              { to: '/sponsor-licence-care-homes', label: 'Sponsor Licence for Care Homes' },
+              { to: '/sponsor-licence-tech-startups', label: 'Sponsor Licence for Tech Startups' },
+              { to: '/sponsor-licence-restaurants', label: 'Sponsor Licence for Restaurants' },
+              { to: '/sponsor-licence-universities', label: 'Sponsor Licence for Universities' },
+            ].map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                style={{ border: `1px solid ${C.border}`, color: C.cream, fontSize: '0.85rem', padding: '10px 18px', borderRadius: '4px', textDecoration: 'none' }}
+                onClick={() => trackSectorLinkClick(to, 'immigration_compliance')}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
+}

--- a/src/components/pages/SponsorLicenceCareHomesPage.tsx
+++ b/src/components/pages/SponsorLicenceCareHomesPage.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { trackCTAClick, trackFAQOpen, trackSectorLinkClick, trackAnchorClick } from '../../lib/analytics';
+
+const C = {
+  navy: '#0B1736',
+  navyMid: '#132048',
+  gold: '#C9A84C',
+  cream: '#F5F1EA',
+  textMuted: '#8a95b0',
+  border: 'rgba(201,168,76,0.2)',
+} as const;
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em',
+  textTransform: 'uppercase', color: C.gold, marginBottom: '16px',
+};
+const h2Style: React.CSSProperties = {
+  fontFamily: "'Cormorant Garamond', serif",
+  fontSize: 'clamp(1.8rem, 3.5vw, 2.8rem)',
+  fontWeight: 700, color: C.cream, lineHeight: 1.2, marginBottom: '20px',
+};
+const h3Style: React.CSSProperties = { fontSize: '1.1rem', fontWeight: 600, color: C.cream, marginBottom: '8px' };
+const pStyle: React.CSSProperties = { color: C.textMuted, marginBottom: '16px' };
+
+const STEPS = [
+  { n: '1', title: 'Free eligibility assessment', desc: 'We review your CQC registration, business structure and intended roles to confirm eligibility and identify any gaps before you apply.' },
+  { n: '2', title: 'Document preparation and HR audit', desc: 'We prepare all required supporting evidence — including HR system review, right to work processes and Authorising Officer designation — to meet Home Office standards.' },
+  { n: '3', title: 'Sponsor licence application submission', desc: 'We submit your application through the Home Office Sponsor Management System and handle any queries. Standard processing is 8 weeks; priority is 10 working days.' },
+  { n: '4', title: 'Certificate of Sponsorship and visa support', desc: 'Once licensed, we assign Certificates of Sponsorship for your workers and support their Health and Care Worker visa applications, including pre-entry and in-country routes.' },
+  { n: '5', title: 'Ongoing compliance and audit readiness', desc: 'We provide a compliance framework covering record-keeping, SMS reporting duties and annual compliance reviews — keeping your licence safe between Home Office visits.' },
+];
+
+const FAQS = [
+  { q: 'Can care homes sponsor overseas workers?', a: 'Yes. Care homes can sponsor overseas care workers and nurses under the Health and Care Worker visa provided they hold a sponsor licence and are registered with the Care Quality Commission (CQC).' },
+  { q: 'What is the Health and Care Worker visa?', a: 'It is a lower-cost, expedited route within the Skilled Worker visa for eligible roles in CQC-regulated adult social care. Application fees are reduced and the Immigration Health Surcharge is exempt for eligible workers. It covers roles such as Care Workers (SOC 6145) and Registered Nurses (SOC 2231).' },
+  { q: 'How long does it take to get a sponsor licence for a care home?', a: 'Standard Home Office processing is 8 weeks. Priority processing takes 10 working days at an additional fee. SoftHire prepares your full application to minimise queries and maximise approval speed.' },
+  { q: 'Does a care home need to be CQC-registered to sponsor workers?', a: 'Yes. For workers to access the Health and Care Worker visa route, the employer must be a CQC-registered adult social care provider. Residential care homes and domiciliary care agencies both qualify if appropriately registered.' },
+  { q: 'What are the ongoing compliance obligations for care home sponsors?', a: 'Sponsors must maintain HR records, carry out right to work checks, monitor worker attendance and immigration status, report changes via the Sponsorship Management System, and keep records available for Home Office inspection at any time.' },
+  { q: 'What happens if the Home Office carries out an unannounced visit?', a: "The Home Office can conduct compliance visits without notice. Sponsors must demonstrate that all HR obligations are being met. SoftHire's compliance framework ensures your records are inspection-ready at all times." },
+];
+
+export default function SponsorLicenceCareHomesPage() {
+  useEffect(() => {
+    document.title = 'Sponsor Licence for Care Homes | UK Immigration for Care Sector | SoftHire';
+  }, []);
+  const [openFAQ, setOpenFAQ] = useState<number | null>(null);
+
+  return (
+    <div style={{ background: C.navy, color: C.cream, lineHeight: 1.7, fontSize: '16px', fontFamily: "'DM Sans', sans-serif" }}>
+
+      {/* ── Hero ── */}
+      <section style={{ padding: '100px 5% 80px', maxWidth: '1100px', margin: '0 auto' }}>
+        <div style={{ display: 'inline-block', border: `1px solid ${C.gold}`, color: C.gold, fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '5px 14px', borderRadius: '2px', marginBottom: '28px' }}>
+          Care Sector · Sponsor Licence
+        </div>
+        <h1 style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: 'clamp(2.4rem, 5vw, 3.8rem)', fontWeight: 700, lineHeight: 1.15, color: C.cream, maxWidth: '820px', marginBottom: '24px' }}>
+          Sponsor Licence for<br />
+          <em style={{ color: C.gold, fontStyle: 'italic' }}>Care Homes</em>
+        </h1>
+        <p style={{ fontSize: '1.1rem', color: C.textMuted, maxWidth: '600px', marginBottom: '40px', fontWeight: 300 }}>
+          Recruit overseas care workers and nurses compliantly. SoftHire handles your sponsor licence
+          application and keeps your care home audit-ready — so you can focus on delivering care.
+        </p>
+        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <Link
+            to={{ pathname: '/', hash: '#contact' }}
+            style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+            onClick={() => trackCTAClick('book_consultation', 'hero_care_homes')}
+          >
+            Get a Free Consultation
+          </Link>
+          <a href="#how-it-works" style={{ border: `1px solid ${C.border}`, color: C.cream, padding: '14px 28px', borderRadius: '4px', textDecoration: 'none', fontSize: '0.95rem' }} onClick={() => trackAnchorClick('see_how_it_works', 'care_homes')}>
+            See how it works →
+          </a>
+        </div>
+      </section>
+
+      {/* ── Trust Bar ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '24px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'flex', gap: '40px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {['IAA-Regulated', '97% Success Rate', 'Fixed-Fee — No Surprises', 'Free Consultation in 24 Hours', 'CQC-Aligned Compliance'].map((label) => (
+            <div key={label} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <span style={{ color: C.gold }}>✦</span>
+              <span style={{ fontSize: '0.85rem', fontWeight: 500, color: C.cream }}>{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Challenge + Who We Help ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '60px' }}>
+            <div>
+              <div style={sectionLabel}>The Challenge</div>
+              <h2 style={h2Style}>The UK care sector runs on international talent</h2>
+              <p style={pStyle}>
+                With over 150,000 care worker vacancies in England alone, many care homes and
+                domiciliary care providers now look overseas to fill critical roles. A UK sponsor
+                licence is the legal gateway to hiring internationally.
+              </p>
+              <p style={pStyle}>
+                Without one, you cannot issue a Certificate of Sponsorship (CoS) — meaning you
+                cannot legally employ candidates on a Skilled Worker or Health and Care Worker visa.
+                Getting it wrong puts your CQC registration and your business at risk.
+              </p>
+              <p style={{ ...pStyle, marginBottom: 0 }}>
+                SoftHire exists to remove that risk. We handle your licence application from end to
+                end, and stay on to support ongoing compliance.
+              </p>
+            </div>
+            <div>
+              <h3 style={{ color: C.gold, fontFamily: "'Cormorant Garamond', serif", fontSize: '1.4rem', marginBottom: '20px' }}>
+                Who we help in the care sector
+              </h3>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {[
+                  'Residential care homes',
+                  'Nursing homes',
+                  'Domiciliary care agencies',
+                  'Supported living providers',
+                  'NHS-commissioned care providers',
+                  'Live-in care companies',
+                  'Care home groups and chains',
+                ].map((item) => (
+                  <li key={item} style={{ display: 'flex', gap: '12px', alignItems: 'flex-start', padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.05)', color: C.cream, fontSize: '0.95rem' }}>
+                    <span style={{ color: C.gold, flexShrink: 0, marginTop: '2px' }}>✦</span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Eligible Roles ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Eligible Roles</div>
+          <h2 style={h2Style}>Which roles can care homes sponsor?</h2>
+          <p style={{ ...pStyle, maxWidth: '680px' }}>
+            The Health and Care Worker visa covers a defined set of roles in CQC-regulated adult
+            social care. Key eligible occupations include:
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginTop: '48px' }}>
+            {[
+              { soc: '6145', title: 'Care Workers & Home Carers', desc: 'The most commonly sponsored role. Minimum salary threshold applies (currently £23,200 or going rate, whichever is higher).' },
+              { soc: '6146', title: 'Senior Care Workers', desc: 'Supervisory care staff. Eligible under the Health and Care Worker visa for CQC-registered providers.' },
+              { soc: '2231', title: 'Registered Nurses', desc: 'Nursing home staff. Must be registered with the NMC. Higher salary threshold applies.' },
+              { soc: '2232', title: 'Occupational Therapists', desc: 'Allied health professionals supporting rehabilitation and daily living.' },
+            ].map(({ soc, title, desc }) => (
+              <div key={soc} style={{ background: C.navy, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+                <div style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: '2.5rem', fontWeight: 700, color: C.gold, opacity: 0.4, lineHeight: 1, marginBottom: '16px' }}>{soc}</div>
+                <h3 style={h3Style}>{title}</h3>
+                <p style={{ ...pStyle, margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── How It Works ── */}
+      <section id="how-it-works" style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Our Process</div>
+          <h2 style={h2Style}>From application to first hire — we handle it</h2>
+          <div style={{ marginTop: '48px' }}>
+            {STEPS.map((step) => (
+              <div key={step.n} style={{ display: 'flex', gap: '28px', marginBottom: '40px', alignItems: 'flex-start' }}>
+                <div style={{ flexShrink: 0, width: '48px', height: '48px', border: `1px solid ${C.gold}`, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: "'Cormorant Garamond', serif", fontSize: '1.3rem', fontWeight: 700, color: C.gold }}>
+                  {step.n}
+                </div>
+                <div>
+                  <h3 style={h3Style}>{step.title}</h3>
+                  <p style={{ ...pStyle, marginBottom: 0 }}>{step.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>FAQ</div>
+          <h2 style={h2Style}>Common questions from care home operators</h2>
+          <div>
+            {FAQS.map((faq, i) => (
+              <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+                <button
+                  onClick={() => { if (openFAQ !== i) trackFAQOpen(faq.q, 'care_homes'); setOpenFAQ(openFAQ === i ? null : i); }}
+                  style={{ width: '100%', textAlign: 'left', padding: '24px 0', background: 'none', border: 'none', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px' }}
+                  aria-expanded={openFAQ === i}
+                >
+                  <span style={{ fontWeight: 600, color: C.cream, fontSize: '1rem' }}>{faq.q}</span>
+                  <span style={{ color: C.gold, flexShrink: 0, fontSize: '1.4rem', lineHeight: 1 }}>{openFAQ === i ? '−' : '+'}</span>
+                </button>
+                {openFAQ === i && (
+                  <div style={{ paddingBottom: '24px', color: C.textMuted, fontSize: '0.95rem', lineHeight: 1.7 }}>{faq.a}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA Band ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '80px 5%', textAlign: 'center' }}>
+        <div style={{ ...sectionLabel, textAlign: 'center' }}>Get Started</div>
+        <h2 style={{ ...h2Style, textAlign: 'center' }}>Ready to sponsor your first care worker?</h2>
+        <p style={{ color: C.textMuted, marginBottom: '36px', maxWidth: '520px', marginLeft: 'auto', marginRight: 'auto' }}>
+          Book a free, no-obligation consultation. We'll assess your eligibility, explain the process
+          and give you a fixed-fee quote — all within 24 hours.
+        </p>
+        <Link
+          to={{ pathname: '/', hash: '#contact' }}
+          style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+          onClick={() => trackCTAClick('book_consultation', 'cta_band_care_homes')}
+        >
+          Book Free Consultation
+        </Link>
+      </div>
+
+      {/* ── Related Links ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Also on SoftHire</div>
+          <h2 style={h2Style}>Other sponsor licence services</h2>
+          <p style={{ ...pStyle }}>We support employers across every sector navigating UK immigration.</p>
+          <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+            {[
+              { to: '/sponsor-licence-tech-startups', label: 'Sponsor Licence for Tech Startups' },
+              { to: '/sponsor-licence-restaurants', label: 'Sponsor Licence for Restaurants' },
+              { to: '/sponsor-licence-universities', label: 'Sponsor Licence for Universities' },
+              { to: '/immigration-compliance', label: 'Immigration Compliance for Agencies' },
+            ].map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                style={{ border: `1px solid ${C.border}`, color: C.cream, fontSize: '0.85rem', padding: '10px 18px', borderRadius: '4px', textDecoration: 'none' }}
+                onClick={() => trackSectorLinkClick(to, 'care_homes')}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
+}

--- a/src/components/pages/SponsorLicenceRestaurantsPage.tsx
+++ b/src/components/pages/SponsorLicenceRestaurantsPage.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { trackCTAClick, trackFAQOpen, trackSectorLinkClick, trackAnchorClick } from '../../lib/analytics';
+
+const C = {
+  navy: '#0B1736',
+  navyMid: '#132048',
+  gold: '#C9A84C',
+  cream: '#F5F1EA',
+  textMuted: '#8a95b0',
+  border: 'rgba(201,168,76,0.2)',
+} as const;
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em',
+  textTransform: 'uppercase', color: C.gold, marginBottom: '16px',
+};
+const h2Style: React.CSSProperties = {
+  fontFamily: "'Cormorant Garamond', serif",
+  fontSize: 'clamp(1.8rem, 3.5vw, 2.8rem)',
+  fontWeight: 700, color: C.cream, lineHeight: 1.2, marginBottom: '20px',
+};
+const h3Style: React.CSSProperties = { fontSize: '1.1rem', fontWeight: 600, color: C.cream, marginBottom: '8px' };
+const pStyle: React.CSSProperties = { color: C.textMuted, marginBottom: '16px' };
+
+const STEPS = [
+  { n: '1', title: 'Role and salary eligibility check', desc: 'We confirm your intended role qualifies under the Skilled Worker route and that your proposed salary meets or exceeds the current threshold. We flag any risks before you commit.' },
+  { n: '2', title: 'Business eligibility verification', desc: 'We review your company registration, trading history and ownership structure to confirm eligibility and identify any gaps the Home Office might raise.' },
+  { n: '3', title: 'HR compliance framework setup', desc: 'We implement right-to-work procedures, monitoring processes and record-keeping templates that meet Home Office standards for your type of hospitality business.' },
+  { n: '4', title: 'Sponsor licence application', desc: 'We submit your full application via the Sponsorship Management System. Standard processing is 8 weeks; priority is 10 working days.' },
+  { n: '5', title: 'Certificate of Sponsorship and visa support', desc: 'Once licensed, we issue Certificates of Sponsorship and support your overseas hires through the full Skilled Worker visa application process.' },
+];
+
+const FAQS = [
+  { q: 'Can UK restaurants sponsor overseas chefs?', a: 'Yes. Restaurants can sponsor overseas chefs under the Skilled Worker visa provided they hold a sponsor licence and the role meets the relevant SOC code, salary threshold and skill level requirements. SoftHire carries out a pre-application eligibility check to confirm this.' },
+  { q: 'Are chefs on the Shortage Occupation List?', a: 'As of 2024, chefs were removed from the UK Shortage Occupation List following the Migration Advisory Committee review. Standard Skilled Worker salary thresholds now apply, which means the minimum salary requirement is higher than it was previously.' },
+  { q: 'What is the minimum salary to sponsor a chef?', a: 'The minimum salary to sponsor a chef (SOC 5434) is currently £30,960 per year, or the going rate for the role, whichever is higher. This reflects the 2024 threshold increases. SoftHire will confirm the exact requirement for your proposed role before application.' },
+  { q: 'Can a single restaurant (not a chain) get a sponsor licence?', a: 'Yes. Individual restaurant businesses can obtain a sponsor licence provided they are a genuine trading business with the required HR processes. SoftHire regularly supports independent restaurant owners.' },
+  { q: 'Can we sponsor kitchen staff on zero-hours contracts?', a: 'No. Sponsored workers must be employed on a contract that guarantees the required minimum salary. Zero-hours arrangements are not compatible with Skilled Worker sponsorship obligations.' },
+  { q: 'What happens if a sponsored chef leaves?', a: 'If a sponsored worker leaves your employment, you must report this via the Sponsorship Management System within 10 working days. The worker must then find alternative sponsorship or leave the UK. SoftHire assists with all reporting obligations.' },
+];
+
+export default function SponsorLicenceRestaurantsPage() {
+  useEffect(() => {
+    document.title = 'Sponsor Licence for Restaurants | Sponsoring Chefs & Kitchen Staff | SoftHire';
+  }, []);
+  const [openFAQ, setOpenFAQ] = useState<number | null>(null);
+
+  return (
+    <div style={{ background: C.navy, color: C.cream, lineHeight: 1.7, fontSize: '16px', fontFamily: "'DM Sans', sans-serif" }}>
+
+      {/* ── Hero ── */}
+      <section style={{ padding: '100px 5% 80px', maxWidth: '1100px', margin: '0 auto' }}>
+        <div style={{ display: 'inline-block', border: `1px solid ${C.gold}`, color: C.gold, fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '5px 14px', borderRadius: '2px', marginBottom: '28px' }}>
+          Hospitality &amp; Food · Sponsor Licence
+        </div>
+        <h1 style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: 'clamp(2.4rem, 5vw, 3.8rem)', fontWeight: 700, lineHeight: 1.15, color: C.cream, maxWidth: '820px', marginBottom: '24px' }}>
+          Sponsor Licence for<br />
+          <em style={{ color: C.gold, fontStyle: 'italic' }}>Restaurants</em>
+        </h1>
+        <p style={{ fontSize: '1.1rem', color: C.textMuted, maxWidth: '600px', marginBottom: '40px', fontWeight: 300 }}>
+          The UK faces a chronic hospitality skills shortage. A sponsor licence lets you recruit the
+          world's best chefs and kitchen talent — legally and without the guesswork.
+        </p>
+        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <Link
+            to={{ pathname: '/', hash: '#contact' }}
+            style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+            onClick={() => trackCTAClick('book_consultation', 'hero_restaurants')}
+          >
+            Get a Free Consultation
+          </Link>
+          <a href="#how-it-works" style={{ border: `1px solid ${C.border}`, color: C.cream, padding: '14px 28px', borderRadius: '4px', textDecoration: 'none', fontSize: '0.95rem' }} onClick={() => trackAnchorClick('see_how_it_works', 'restaurants')}>
+            See how it works →
+          </a>
+        </div>
+      </section>
+
+      {/* ── Trust Bar ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '24px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'flex', gap: '40px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {['IAA-Regulated', '97% Success Rate', 'Fixed-Fee', 'Independent & Chain Restaurants', 'Chefs & Management Roles'].map((label) => (
+            <div key={label} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <span style={{ color: C.gold }}>✦</span>
+              <span style={{ fontSize: '0.85rem', fontWeight: 500, color: C.cream }}>{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Challenge + Who We Support ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '60px' }}>
+            <div>
+              <div style={sectionLabel}>The Challenge</div>
+              <h2 style={h2Style}>UK hospitality is short-staffed. International recruitment is the answer.</h2>
+              <p style={pStyle}>
+                Post-Brexit, UK restaurants lost immediate access to EU labour pools. Combined with
+                the domestic cost-of-living crisis making hospitality careers less attractive, many
+                operators are struggling to fill critical kitchen roles.
+              </p>
+              <p style={pStyle}>
+                A sponsor licence opens the door to talent from every culinary tradition — from
+                specialist ethnic cuisine chefs to trained pastry professionals.
+              </p>
+              {/* Alert box */}
+              <div style={{ background: 'rgba(201,168,76,0.08)', border: `1px solid ${C.gold}`, borderRadius: '8px', padding: '24px 28px', marginTop: '8px' }}>
+                <p style={{ color: C.cream, fontSize: '0.95rem', margin: 0 }}>
+                  <strong style={{ color: C.gold }}>Important:</strong> Chefs were removed from the
+                  Shortage Occupation List in 2024. Standard Skilled Worker salary thresholds now
+                  apply. SoftHire will assess whether your proposed role and salary structure
+                  qualifies before you apply.
+                </p>
+              </div>
+            </div>
+            <div>
+              <h3 style={{ color: C.gold, fontFamily: "'Cormorant Garamond', serif", fontSize: '1.4rem', marginBottom: '20px' }}>
+                We support all types of food business
+              </h3>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {[
+                  'Independent restaurants',
+                  'Restaurant chains and groups',
+                  'Ethnic and specialist cuisine restaurants',
+                  'Fine dining establishments',
+                  'Hotels and resort food & beverage',
+                  'Catering companies',
+                  'Dark kitchens and delivery-first operators',
+                ].map((item) => (
+                  <li key={item} style={{ display: 'flex', gap: '12px', alignItems: 'flex-start', padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.05)', color: C.cream, fontSize: '0.95rem' }}>
+                    <span style={{ color: C.gold, flexShrink: 0, marginTop: '2px' }}>✦</span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Eligible Roles ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Eligible Roles</div>
+          <h2 style={h2Style}>Which hospitality roles can be sponsored?</h2>
+          <p style={{ ...pStyle, maxWidth: '680px' }}>
+            A range of kitchen and management roles in hospitality qualify under the Skilled Worker
+            route. Eligibility depends on SOC code, salary and role specification.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginTop: '48px' }}>
+            {[
+              { soc: '5434', title: 'Chefs', desc: 'The most common role sponsored by restaurants. Minimum salary currently £30,960 or going rate. Must demonstrate relevant skills and experience.' },
+              { soc: '1223', title: 'Restaurant & Catering Managers', desc: 'General managers and operations leads overseeing food service businesses. Higher salary thresholds apply.' },
+              { soc: '5435', title: 'Cooks', desc: 'Specialist cooks, including pastry chefs and ethnic cuisine specialists. Eligibility depends on role specification.' },
+              { soc: '1224', title: 'Publicans & Hospitality Managers', desc: 'Managers of licensed premises including bars, pubs and hospitality venues.' },
+            ].map(({ soc, title, desc }) => (
+              <div key={soc} style={{ background: C.navy, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+                <div style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: '2rem', fontWeight: 700, color: C.gold, opacity: 0.4, lineHeight: 1, marginBottom: '16px' }}>{soc}</div>
+                <h3 style={h3Style}>{title}</h3>
+                <p style={{ ...pStyle, margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── How It Works ── */}
+      <section id="how-it-works" style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Our Process</div>
+          <h2 style={h2Style}>How SoftHire gets you sponsor-licensed</h2>
+          <div style={{ marginTop: '48px' }}>
+            {STEPS.map((step) => (
+              <div key={step.n} style={{ display: 'flex', gap: '28px', marginBottom: '40px', alignItems: 'flex-start' }}>
+                <div style={{ flexShrink: 0, width: '48px', height: '48px', border: `1px solid ${C.gold}`, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: "'Cormorant Garamond', serif", fontSize: '1.3rem', fontWeight: 700, color: C.gold }}>
+                  {step.n}
+                </div>
+                <div>
+                  <h3 style={h3Style}>{step.title}</h3>
+                  <p style={{ ...pStyle, marginBottom: 0 }}>{step.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>FAQ</div>
+          <h2 style={h2Style}>Questions from restaurant owners</h2>
+          <div>
+            {FAQS.map((faq, i) => (
+              <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+                <button
+                  onClick={() => { if (openFAQ !== i) trackFAQOpen(faq.q, 'restaurants'); setOpenFAQ(openFAQ === i ? null : i); }}
+                  style={{ width: '100%', textAlign: 'left', padding: '24px 0', background: 'none', border: 'none', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px' }}
+                  aria-expanded={openFAQ === i}
+                >
+                  <span style={{ fontWeight: 600, color: C.cream, fontSize: '1rem' }}>{faq.q}</span>
+                  <span style={{ color: C.gold, flexShrink: 0, fontSize: '1.4rem', lineHeight: 1 }}>{openFAQ === i ? '−' : '+'}</span>
+                </button>
+                {openFAQ === i && (
+                  <div style={{ paddingBottom: '24px', color: C.textMuted, fontSize: '0.95rem', lineHeight: 1.7 }}>{faq.a}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA Band ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '80px 5%', textAlign: 'center' }}>
+        <div style={{ ...sectionLabel, textAlign: 'center' }}>Get Started</div>
+        <h2 style={{ ...h2Style, textAlign: 'center' }}>Your kitchen shouldn't run short because of paperwork.</h2>
+        <p style={{ color: C.textMuted, marginBottom: '36px', maxWidth: '520px', marginLeft: 'auto', marginRight: 'auto' }}>
+          Book a free consultation. We'll check your eligibility, explain the salary requirements and
+          give you a fixed-fee quote — all within 24 hours.
+        </p>
+        <Link
+          to={{ pathname: '/', hash: '#contact' }}
+          style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+          onClick={() => trackCTAClick('book_consultation', 'cta_band_restaurants')}
+        >
+          Book Free Consultation
+        </Link>
+      </div>
+
+      {/* ── Related Links ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Also on SoftHire</div>
+          <h2 style={h2Style}>Other sponsor licence services</h2>
+          <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+            {[
+              { to: '/sponsor-licence-care-homes', label: 'Sponsor Licence for Care Homes' },
+              { to: '/sponsor-licence-tech-startups', label: 'Sponsor Licence for Tech Startups' },
+              { to: '/sponsor-licence-universities', label: 'Sponsor Licence for Universities' },
+              { to: '/immigration-compliance', label: 'Immigration Compliance for Agencies' },
+            ].map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                style={{ border: `1px solid ${C.border}`, color: C.cream, fontSize: '0.85rem', padding: '10px 18px', borderRadius: '4px', textDecoration: 'none' }}
+                onClick={() => trackSectorLinkClick(to, 'restaurants')}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
+}

--- a/src/components/pages/SponsorLicenceTechStartupsPage.tsx
+++ b/src/components/pages/SponsorLicenceTechStartupsPage.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { trackCTAClick, trackFAQOpen, trackSectorLinkClick, trackAnchorClick } from '../../lib/analytics';
+
+const C = {
+  navy: '#0B1736',
+  navyMid: '#132048',
+  navyLight: '#1e2f5e',
+  gold: '#C9A84C',
+  cream: '#F5F1EA',
+  textMuted: '#8a95b0',
+  border: 'rgba(201,168,76,0.2)',
+} as const;
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em',
+  textTransform: 'uppercase', color: C.gold, marginBottom: '16px',
+};
+const h2Style: React.CSSProperties = {
+  fontFamily: "'Cormorant Garamond', serif",
+  fontSize: 'clamp(1.8rem, 3.5vw, 2.8rem)',
+  fontWeight: 700, color: C.cream, lineHeight: 1.2, marginBottom: '20px',
+};
+const h3Style: React.CSSProperties = { fontSize: '1.1rem', fontWeight: 600, color: C.cream, marginBottom: '8px' };
+const pStyle: React.CSSProperties = { color: C.textMuted, marginBottom: '16px' };
+
+const STEPS = [
+  { n: '1', title: 'Eligibility check — same day', desc: 'We confirm your company structure, shareholding and role requirements qualify. If there are gaps, we tell you clearly what to fix and how.' },
+  { n: '2', title: 'Lean HR compliance setup', desc: 'We build right-to-work processes and record-keeping templates designed for a lean People function — not a corporate HR department. Quick to implement, Home Office-compliant.' },
+  { n: '3', title: 'Application submitted — priority if needed', desc: 'We submit your full application via the Sponsorship Management System. Priority processing is 10 working days. Standard is 8 weeks.' },
+  { n: '4', title: 'CoS assigned and visa application supported', desc: 'Once licensed, we assign Certificates of Sponsorship and support visa applications for your hires — covering both overseas and in-country candidates.' },
+  { n: '5', title: 'Compliance maintained as you scale', desc: 'As your headcount grows, your compliance obligations grow. We provide a scalable framework and are on hand for every new hire, extension and corporate change.' },
+];
+
+const FAQS = [
+  { q: 'Can a pre-revenue startup get a sponsor licence?', a: 'Yes. The Home Office does not require profitability or revenue. A startup must demonstrate it is a genuine trading organisation with appropriate HR systems and the capacity to pay the sponsored worker at or above the relevant salary threshold.' },
+  { q: 'What is the minimum salary for sponsored software developers?', a: 'Software developers and programmers (SOC 2136) must be paid at least £40,880 per year or the going rate for the role, whichever is higher. New entrant rates may apply for qualifying candidates with less experience.' },
+  { q: 'Can equity or bonuses count towards the salary threshold?', a: 'No. Only guaranteed basic salary and certain fixed allowances count. Equity, bonuses and commission are excluded from the threshold calculation — a common issue for early-stage startups offering equity-heavy packages.' },
+  { q: 'How quickly can a startup get a sponsor licence?', a: 'Standard Home Office processing is 8 weeks. Priority processing is 10 working days at additional cost. Where a candidate is already in the UK on another valid visa, their employment can sometimes begin while the licence is processing.' },
+  { q: 'What happens to sponsored employees if the startup is acquired?', a: "A TUPE transfer or acquisition does not automatically invalidate a sponsored worker's visa, but the new employer must hold or obtain a sponsor licence and the worker's details must be updated on the Sponsorship Management System. SoftHire supports startups through corporate transactions and exits." },
+  { q: 'Do we need a dedicated HR team to hold a sponsor licence?', a: 'No. You need an Authorising Officer and a Key Contact (these can be the same person, often a founder or COO), plus documented right-to-work and monitoring processes. SoftHire builds and maintains these for you.' },
+];
+
+export default function SponsorLicenceTechStartupsPage() {
+  useEffect(() => {
+    document.title = 'Sponsor Licence for Tech Startups | Skilled Worker Visas for Startups | SoftHire';
+  }, []);
+  const [openFAQ, setOpenFAQ] = useState<number | null>(null);
+
+  return (
+    <div style={{ background: C.navy, color: C.cream, lineHeight: 1.7, fontSize: '16px', fontFamily: "'DM Sans', sans-serif" }}>
+
+      {/* ── Hero ── */}
+      <section style={{ padding: '100px 5% 80px', maxWidth: '1100px', margin: '0 auto' }}>
+        <div style={{ display: 'inline-block', border: `1px solid ${C.gold}`, color: C.gold, fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '5px 14px', borderRadius: '2px', marginBottom: '28px' }}>
+          Tech &amp; Startups · Sponsor Licence
+        </div>
+        <h1 style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: 'clamp(2.4rem, 5vw, 3.8rem)', fontWeight: 700, lineHeight: 1.15, color: C.cream, maxWidth: '820px', marginBottom: '24px' }}>
+          Sponsor Licence for<br />
+          <em style={{ color: C.gold, fontStyle: 'italic' }}>Tech Startups</em>
+        </h1>
+        <p style={{ fontSize: '1.1rem', color: C.textMuted, maxWidth: '600px', marginBottom: '40px', fontWeight: 300 }}>
+          The best engineers aren't always in the UK. SoftHire gets you sponsor-licensed fast so you
+          can hire globally, compliantly, and without slowing your roadmap.
+        </p>
+        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <Link
+            to={{ pathname: '/', hash: '#contact' }}
+            style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+            onClick={() => trackCTAClick('book_consultation', 'hero_tech_startups')}
+          >
+            Get a Free Consultation
+          </Link>
+          <a href="#how-it-works" style={{ border: `1px solid ${C.border}`, color: C.cream, padding: '14px 28px', borderRadius: '4px', textDecoration: 'none', fontSize: '0.95rem' }} onClick={() => trackAnchorClick('see_how_it_works', 'tech_startups')}>
+            See how it works →
+          </a>
+        </div>
+      </section>
+
+      {/* ── Trust Bar ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '24px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'flex', gap: '40px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {['IAA-Regulated', '97% Success Rate', 'Fixed-Fee', 'Works for Pre-Revenue Startups', 'Founder-Led Immigration'].map((label) => (
+            <div key={label} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <span style={{ color: C.gold }}>✦</span>
+              <span style={{ fontSize: '0.85rem', fontWeight: 500, color: C.cream }}>{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Problem + Stages ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '60px' }}>
+            <div>
+              <div style={sectionLabel}>The Problem</div>
+              <h2 style={h2Style}>Great candidates don't stop at borders. Your hiring process shouldn't either.</h2>
+              <p style={pStyle}>
+                London, Manchester and Edinburgh produce world-class tech talent — but so does every
+                city from Lagos to Lahore. The startups winning the talent war have one thing their
+                competition doesn't: a sponsor licence.
+              </p>
+              <p style={pStyle}>
+                Without one, you're limited to UK/settled workers in an already constrained market.
+                With one, you can make offers to global candidates in days, not months.
+              </p>
+              <p style={pStyle}>
+                SoftHire is built for startups. We understand your pace, your lean HR function, and
+                the fact that your lead engineers can't wait eight weeks while paperwork piles up.
+              </p>
+              {/* Highlight box */}
+              <div style={{ background: C.navyLight, borderLeft: `3px solid ${C.gold}`, padding: '24px 28px', borderRadius: '0 8px 8px 0', marginTop: '8px' }}>
+                <p style={{ color: C.cream, margin: 0 }}>
+                  <strong style={{ color: C.gold }}>Founder note:</strong> SoftHire was built by a
+                  lawyer-founder who understands startup constraints. We've designed our process to
+                  work around your sprint cycles, not against them.
+                </p>
+              </div>
+            </div>
+            <div>
+              <h3 style={{ color: C.gold, fontFamily: "'Cormorant Garamond', serif", fontSize: '1.4rem', marginBottom: '20px' }}>
+                We work with startups at every stage
+              </h3>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {[
+                  'Pre-seed and seed stage companies',
+                  'Series A and Series B',
+                  'VC-backed and bootstrapped startups',
+                  'Y Combinator and accelerator alumni',
+                  'Scale-ups expanding UK headcount',
+                  'Startups with no dedicated People team',
+                  'Companies acquiring talent via TUPE',
+                ].map((item) => (
+                  <li key={item} style={{ display: 'flex', gap: '12px', alignItems: 'flex-start', padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.05)', color: C.cream, fontSize: '0.95rem' }}>
+                    <span style={{ color: C.gold, flexShrink: 0, marginTop: '2px' }}>✦</span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Eligible Roles ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Eligible Roles</div>
+          <h2 style={h2Style}>Which tech roles can startups sponsor?</h2>
+          <p style={{ ...pStyle, maxWidth: '680px' }}>
+            Most senior technical and product roles qualify for sponsorship under the Skilled Worker
+            route. Common SOC codes for the tech sector include:
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginTop: '48px' }}>
+            {[
+              { icon: '⌨️', title: 'Software Developers (SOC 2136)', desc: 'Backend, frontend, full-stack. The most commonly sponsored tech role. Minimum salary £40,880 or going rate.' },
+              { icon: '🔬', title: 'Data Scientists (SOC 2425)', desc: 'ML engineers, data analysts and AI researchers. High demand, strong eligibility.' },
+              { icon: '🔧', title: 'IT Project & Programme Managers (SOC 1136)', desc: 'Technical PMs and engineering leads. Eligible under the Skilled Worker route.' },
+              { icon: '🔐', title: 'Cybersecurity Specialists (SOC 2139)', desc: 'Security engineers and penetration testers. Strong labour market case for sponsorship.' },
+              { icon: '📐', title: 'UX/UI Designers (SOC 2166)', desc: 'Product designers and UX researchers may qualify depending on the role specification.' },
+              { icon: '☁️', title: 'IT Systems Architects (SOC 2135)', desc: 'Cloud architects, infrastructure engineers and DevOps leads.' },
+            ].map(({ icon, title, desc }) => (
+              <div key={title} style={{ background: C.navy, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+                <div style={{ fontSize: '1.8rem', marginBottom: '16px' }}>{icon}</div>
+                <h3 style={h3Style}>{title}</h3>
+                <p style={{ ...pStyle, margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── How It Works ── */}
+      <section id="how-it-works" style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Our Process</div>
+          <h2 style={h2Style}>Sponsor-licensed without slowing you down</h2>
+          <div style={{ marginTop: '48px' }}>
+            {STEPS.map((step) => (
+              <div key={step.n} style={{ display: 'flex', gap: '28px', marginBottom: '40px', alignItems: 'flex-start' }}>
+                <div style={{ flexShrink: 0, width: '48px', height: '48px', border: `1px solid ${C.gold}`, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: "'Cormorant Garamond', serif", fontSize: '1.3rem', fontWeight: 700, color: C.gold }}>
+                  {step.n}
+                </div>
+                <div>
+                  <h3 style={h3Style}>{step.title}</h3>
+                  <p style={{ ...pStyle, marginBottom: 0 }}>{step.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>FAQ</div>
+          <h2 style={h2Style}>What founders ask us most</h2>
+          <div>
+            {FAQS.map((faq, i) => (
+              <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+                <button
+                  onClick={() => { if (openFAQ !== i) trackFAQOpen(faq.q, 'tech_startups'); setOpenFAQ(openFAQ === i ? null : i); }}
+                  style={{ width: '100%', textAlign: 'left', padding: '24px 0', background: 'none', border: 'none', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px' }}
+                  aria-expanded={openFAQ === i}
+                >
+                  <span style={{ fontWeight: 600, color: C.cream, fontSize: '1rem' }}>{faq.q}</span>
+                  <span style={{ color: C.gold, flexShrink: 0, fontSize: '1.4rem', lineHeight: 1 }}>{openFAQ === i ? '−' : '+'}</span>
+                </button>
+                {openFAQ === i && (
+                  <div style={{ paddingBottom: '24px', color: C.textMuted, fontSize: '0.95rem', lineHeight: 1.7 }}>{faq.a}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA Band ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '80px 5%', textAlign: 'center' }}>
+        <div style={{ ...sectionLabel, textAlign: 'center' }}>Get Started</div>
+        <h2 style={{ ...h2Style, textAlign: 'center' }}>Stop losing hires to visa uncertainty.</h2>
+        <p style={{ color: C.textMuted, marginBottom: '36px', maxWidth: '520px', marginLeft: 'auto', marginRight: 'auto' }}>
+          Book a free consultation. We'll assess your eligibility and give you a fixed-fee quote
+          within 24 hours — so you can make that offer with confidence.
+        </p>
+        <Link
+          to={{ pathname: '/', hash: '#contact' }}
+          style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+          onClick={() => trackCTAClick('book_consultation', 'cta_band_tech_startups')}
+        >
+          Book Free Consultation
+        </Link>
+      </div>
+
+      {/* ── Related Links ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Also on SoftHire</div>
+          <h2 style={h2Style}>Other sponsor licence services</h2>
+          <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+            {[
+              { to: '/sponsor-licence-care-homes', label: 'Sponsor Licence for Care Homes' },
+              { to: '/sponsor-licence-restaurants', label: 'Sponsor Licence for Restaurants' },
+              { to: '/sponsor-licence-universities', label: 'Sponsor Licence for Universities' },
+              { to: '/immigration-compliance', label: 'Immigration Compliance for Agencies' },
+            ].map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                style={{ border: `1px solid ${C.border}`, color: C.cream, fontSize: '0.85rem', padding: '10px 18px', borderRadius: '4px', textDecoration: 'none' }}
+                onClick={() => trackSectorLinkClick(to, 'tech_startups')}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
+}

--- a/src/components/pages/SponsorLicenceUniversitiesPage.tsx
+++ b/src/components/pages/SponsorLicenceUniversitiesPage.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { trackCTAClick, trackFAQOpen, trackSectorLinkClick, trackAnchorClick } from '../../lib/analytics';
+
+const C = {
+  navy: '#0B1736',
+  navyMid: '#132048',
+  gold: '#C9A84C',
+  cream: '#F5F1EA',
+  textMuted: '#8a95b0',
+  border: 'rgba(201,168,76,0.2)',
+} as const;
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em',
+  textTransform: 'uppercase', color: C.gold, marginBottom: '16px',
+};
+const h2Style: React.CSSProperties = {
+  fontFamily: "'Cormorant Garamond', serif",
+  fontSize: 'clamp(1.8rem, 3.5vw, 2.8rem)',
+  fontWeight: 700, color: C.cream, lineHeight: 1.2, marginBottom: '20px',
+};
+const h3Style: React.CSSProperties = { fontSize: '1.1rem', fontWeight: 600, color: C.cream, marginBottom: '8px' };
+const pStyle: React.CSSProperties = { color: C.textMuted, marginBottom: '16px' };
+
+const FAQS = [
+  { q: 'Do UK universities need separate licences for students and staff?', a: "Yes. Universities typically hold two separate sponsor licences: a Student sponsor licence to enrol international students, and a Worker sponsor licence (Skilled Worker route) to employ overseas academics, researchers and professional services staff. Each has distinct compliance obligations." },
+  { q: 'What is a UKVI compliance audit for universities?', a: 'UKVI conducts compliance visits to sponsor licence holders, including universities, to verify that they are meeting all sponsor duties. These can be announced or unannounced and assess record-keeping, attendance monitoring and reporting obligations for both students and staff.' },
+  { q: 'What visa route do overseas academics use to work at UK universities?', a: 'Overseas academics typically use the Skilled Worker visa route under SOC 2311. Short-term visiting academics may use the Visitor visa. Senior academics of exceptional ability may qualify for the Global Talent visa, which is employer-independent and may be more appropriate for high-profile hires.' },
+  { q: 'Can universities sponsor overseas PhD students as workers?', a: 'PhD students who perform demonstrable work (e.g. funded research roles, associate teaching roles) may be eligible for sponsorship as workers in addition to or instead of the Student route. The appropriate route depends on the nature of the role and funding structure.' },
+  { q: 'What happens if a university loses its sponsor licence?', a: "Loss of a sponsor licence is existential for a university. It immediately affects the ability to enrol new international students and employ overseas staff, and existing sponsored individuals may have their leave curtailed. Proactive compliance is far less costly than remediation." },
+  { q: 'Do post-92 universities face greater UKVI scrutiny?', a: 'Post-92 and smaller Higher Education providers are subject to the same UKVI compliance requirements as Russell Group universities but may have less developed compliance infrastructure. SoftHire works extensively with post-92 institutions to build robust, audit-ready processes.' },
+];
+
+export default function SponsorLicenceUniversitiesPage() {
+  useEffect(() => {
+    document.title = 'Sponsor Licence for Universities | Student & Worker Sponsorship | SoftHire';
+  }, []);
+  const [openFAQ, setOpenFAQ] = useState<number | null>(null);
+
+  return (
+    <div style={{ background: C.navy, color: C.cream, lineHeight: 1.7, fontSize: '16px', fontFamily: "'DM Sans', sans-serif" }}>
+
+      {/* ── Hero ── */}
+      <section style={{ padding: '100px 5% 80px', maxWidth: '1100px', margin: '0 auto' }}>
+        <div style={{ display: 'inline-block', border: `1px solid ${C.gold}`, color: C.gold, fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '5px 14px', borderRadius: '2px', marginBottom: '28px' }}>
+          Higher Education · Sponsor Licence
+        </div>
+        <h1 style={{ fontFamily: "'Cormorant Garamond', serif", fontSize: 'clamp(2.4rem, 5vw, 3.8rem)', fontWeight: 700, lineHeight: 1.15, color: C.cream, maxWidth: '820px', marginBottom: '24px' }}>
+          Sponsor Licence for<br />
+          <em style={{ color: C.gold, fontStyle: 'italic' }}>Universities</em>
+        </h1>
+        <p style={{ fontSize: '1.1rem', color: C.textMuted, maxWidth: '600px', marginBottom: '40px', fontWeight: 300 }}>
+          Managing student and worker sponsorship simultaneously is complex. SoftHire provides the
+          compliance infrastructure, audit support and immigration expertise that Higher Education
+          institutions need.
+        </p>
+        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <Link
+            to={{ pathname: '/', hash: '#contact' }}
+            style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+            onClick={() => trackCTAClick('book_consultation', 'hero_universities')}
+          >
+            Book a Consultation
+          </Link>
+          <a href="#services" style={{ border: `1px solid ${C.border}`, color: C.cream, padding: '14px 28px', borderRadius: '4px', textDecoration: 'none', fontSize: '0.95rem' }} onClick={() => trackAnchorClick('see_services', 'universities')}>
+            See our services →
+          </a>
+        </div>
+      </section>
+
+      {/* ── Trust Bar ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '24px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'flex', gap: '40px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {['IAA-Regulated', '97% Success Rate', 'Student & Worker Sponsor Licences', 'UKVI Audit Readiness', 'Fixed-Fee'].map((label) => (
+            <div key={label} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <span style={{ color: C.gold }}>✦</span>
+              <span style={{ fontSize: '0.85rem', fontWeight: 500, color: C.cream }}>{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Dual Routes ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>The Complexity</div>
+          <h2 style={h2Style}>Universities manage two sponsor licences at once</h2>
+          <p style={{ ...pStyle, maxWidth: '680px' }}>
+            Most UK Higher Education institutions hold both a Student sponsor licence and a Worker
+            sponsor licence — each with its own compliance obligations, reporting duties and audit risks.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '24px', marginTop: '40px' }}>
+            <div style={{ background: C.navyMid, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+              <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em', textTransform: 'uppercase', color: C.gold, marginBottom: '12px' }}>Student Route</div>
+              <h3 style={h3Style}>Student Sponsor Licence</h3>
+              <p style={{ ...pStyle, marginBottom: 0 }}>
+                Required to enrol non-EEA students. Universities must track attendance, course
+                progression and report students who discontinue or become non-compliant. Loss of
+                Highly Trusted Sponsor status can be existential for international student recruitment.
+              </p>
+            </div>
+            <div style={{ background: C.navyMid, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+              <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.14em', textTransform: 'uppercase', color: C.gold, marginBottom: '12px' }}>Worker Route</div>
+              <h3 style={h3Style}>Worker Sponsor Licence</h3>
+              <p style={{ ...pStyle, marginBottom: 0 }}>
+                Required to employ overseas academics, researchers, professional services and
+                technical staff. Roles must meet Skilled Worker SOC code and salary requirements.
+                Different duties to Student route but often managed by the same compliance team.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Services ── */}
+      <section id="services" style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Services</div>
+          <h2 style={h2Style}>What SoftHire does for universities</h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginTop: '48px' }}>
+            {[
+              { icon: '🎓', title: 'Student Sponsor Licence Applications', desc: 'New licence applications for emerging institutions, branch campuses and independent colleges seeking to recruit international students.' },
+              { icon: '👨‍🔬', title: 'Academic Recruitment Visas', desc: 'Skilled Worker visa support for overseas professors, lecturers, post-doctoral researchers and visiting academics.' },
+              { icon: '🔍', title: 'UKVI Audit Preparation', desc: 'Mock audit exercises, gap analysis and record remediation to ensure your institution is compliant ahead of a UKVI visit — announced or otherwise.' },
+              { icon: '📋', title: 'Compliance Policy Development', desc: 'Drafting and implementing UKVI-compliant immigration policies, right-to-work procedures and sponsor duty frameworks for HR teams.' },
+              { icon: '🌐', title: 'Global Talent Visa Support', desc: 'Guidance on the Global Talent route for world-leading researchers and academics — an alternative to Skilled Worker for exceptional candidates.' },
+              { icon: '⚠️', title: 'Licence Downgrade & Revocation Response', desc: 'Urgent support for institutions facing licence suspension, downgrade or revocation — including representation and compliance remediation plans.' },
+            ].map(({ icon, title, desc }) => (
+              <div key={title} style={{ background: C.navy, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+                <div style={{ fontSize: '1.8rem', marginBottom: '16px' }}>{icon}</div>
+                <h3 style={h3Style}>{title}</h3>
+                <p style={{ ...pStyle, margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Eligible Academic Roles ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Eligible Academic Roles</div>
+          <h2 style={h2Style}>Which academic roles can universities sponsor?</h2>
+          <p style={{ ...pStyle, maxWidth: '680px' }}>
+            A broad range of academic, research and professional services roles qualify for Skilled
+            Worker sponsorship. Common SOC codes in Higher Education include:
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginTop: '32px' }}>
+            {[
+              { title: 'Higher Education Teaching Professionals (SOC 2311)', desc: 'Lecturers, senior lecturers, professors and associate professors. The most commonly sponsored academic role.' },
+              { title: 'Research Scientists & Academics (SOC 2111–2119)', desc: 'Postdoctoral researchers, senior research fellows and principal investigators across sciences and humanities.' },
+              { title: 'IT and Systems Professionals (SOC 2130s)', desc: 'University IT staff, research computing specialists and data engineers supporting academic infrastructure.' },
+              { title: 'Professional Services Roles', desc: 'Finance, legal, HR and technical roles that meet Skilled Worker thresholds and skill level requirements.' },
+            ].map(({ title, desc }) => (
+              <div key={title} style={{ background: C.navyMid, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '32px 28px' }}>
+                <h3 style={h3Style}>{title}</h3>
+                <p style={{ ...pStyle, margin: 0 }}>{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ── */}
+      <section style={{ padding: '80px 5%', background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>FAQ</div>
+          <h2 style={h2Style}>Common questions from HE institutions</h2>
+          <div>
+            {FAQS.map((faq, i) => (
+              <div key={i} style={{ borderBottom: `1px solid ${C.border}` }}>
+                <button
+                  onClick={() => { if (openFAQ !== i) trackFAQOpen(faq.q, 'universities'); setOpenFAQ(openFAQ === i ? null : i); }}
+                  style={{ width: '100%', textAlign: 'left', padding: '24px 0', background: 'none', border: 'none', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px' }}
+                  aria-expanded={openFAQ === i}
+                >
+                  <span style={{ fontWeight: 600, color: C.cream, fontSize: '1rem' }}>{faq.q}</span>
+                  <span style={{ color: C.gold, flexShrink: 0, fontSize: '1.4rem', lineHeight: 1 }}>{openFAQ === i ? '−' : '+'}</span>
+                </button>
+                {openFAQ === i && (
+                  <div style={{ paddingBottom: '24px', color: C.textMuted, fontSize: '0.95rem', lineHeight: 1.7 }}>{faq.a}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA Band ── */}
+      <div style={{ background: C.navyMid, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}`, padding: '80px 5%', textAlign: 'center' }}>
+        <div style={{ ...sectionLabel, textAlign: 'center' }}>Get Started</div>
+        <h2 style={{ ...h2Style, textAlign: 'center' }}>Keep your institution audit-ready and compliant.</h2>
+        <p style={{ color: C.textMuted, marginBottom: '36px', maxWidth: '520px', marginLeft: 'auto', marginRight: 'auto' }}>
+          Book a consultation with our HE immigration specialists. We'll assess your current
+          compliance posture and identify where the risks are — before UKVI does.
+        </p>
+        <Link
+          to={{ pathname: '/', hash: '#contact' }}
+          style={{ background: C.gold, color: C.navy, fontWeight: 600, fontSize: '0.95rem', padding: '14px 32px', borderRadius: '4px', textDecoration: 'none' }}
+          onClick={() => trackCTAClick('book_consultation', 'cta_band_universities')}
+        >
+          Book Free Consultation
+        </Link>
+      </div>
+
+      {/* ── Related Links ── */}
+      <section style={{ padding: '80px 5%' }}>
+        <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+          <div style={sectionLabel}>Also on SoftHire</div>
+          <h2 style={h2Style}>Other sponsor licence services</h2>
+          <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+            {[
+              { to: '/sponsor-licence-care-homes', label: 'Sponsor Licence for Care Homes' },
+              { to: '/sponsor-licence-tech-startups', label: 'Sponsor Licence for Tech Startups' },
+              { to: '/sponsor-licence-restaurants', label: 'Sponsor Licence for Restaurants' },
+              { to: '/immigration-compliance', label: 'Immigration Compliance for Agencies' },
+            ].map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                style={{ border: `1px solid ${C.border}`, color: C.cream, fontSize: '0.85rem', padding: '10px 18px', borderRadius: '4px', textDecoration: 'none' }}
+                onClick={() => trackSectorLinkClick(to, 'universities')}
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+    </div>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -117,3 +117,30 @@ export function trackFooterClick(label: string): void {
     event_label: label,
   });
 }
+
+/** Track a FAQ accordion item being opened (not closed). */
+export function trackFAQOpen(question: string, page: string): void {
+  trackEvent('faq_open', {
+    event_category: 'engagement',
+    event_label: question.substring(0, 100),
+    page_section: page,
+  });
+}
+
+/** Track a sector/related page internal link click. */
+export function trackSectorLinkClick(destination: string, source: string): void {
+  trackEvent('sector_link_click', {
+    event_category: 'navigation',
+    event_label: destination,
+    source_page: source,
+  });
+}
+
+/** Track a ghost / secondary anchor CTA click. */
+export function trackAnchorClick(label: string, page: string): void {
+  trackEvent('anchor_click', {
+    event_category: 'engagement',
+    event_label: label,
+    page_section: page,
+  });
+}


### PR DESCRIPTION
Introduce four new sponsor-licence pages and an immigration compliance page (Care Homes, Restaurants, Tech Startups, Universities, Recruitment Agencies). Wire them into the app by adding imports and Routes in App.tsx, and add a HashScrollHandler to handle SPA hash navigation. Update Header and Footer to expose a new Sectors menu (desktop dropdown + mobile links) with tracking hooks, adjust footer layout, and add sector links across pages. Minor frontend changes: update Google Fonts and favicon in index.html and adjust analytics usage (src/lib/analytics.ts) to support new tracking events.