### PR TITLE
Refocus site on sponsor licence & compliance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,8 +104,8 @@ function TrailingSlashRedirect() {
 const HomePage = () => (
   <>
     <SEO
-      title="UK Visa & Immigration Services | Student, Skilled Worker, Sponsor Licence | SoftHire"
-      description="IAA-regulated UK immigration experts. Fixed-fee Student, Graduate, Skilled Worker visas and Sponsor Licences. 97% success rate. Free consultation in 24 hours."
+      title="Sponsor Licence & Skilled Worker Compliance Support for UK Employers | SoftHire"
+      description="IAA-regulated sponsor licence applications, Skilled Worker visa support and compliance retainers for UK employers. Fixed fees. Book a free assessment."
       path="/"
     />
     <Hero />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,139 +1,408 @@
-﻿const About = () => {
-  const trustStats = [
-    { icon: "🇬🇧", num: "IAA", label: "Regulated by the UK Immigration Advice Authority" },
-    { icon: "⚡", num: "3 wks", label: "Average time from first contact to submission-ready application" },
-    { icon: "🎯", num: "97%", label: "UK visa success rate — published openly, not hidden in the small print" },
-    { icon: "💷", num: "Fixed", label: "Fee pricing with zero hidden costs. Know exactly what you will pay before you start" },
-  ];
+﻿import { ArrowRight, ShieldCheck } from 'lucide-react';
+import { trackCTAClick } from '../lib/analytics';
 
-  const testimonials = [
-    {
-      text: "I was terrified of getting my student visa wrong and losing my place at Manchester. SoftHire made the whole process feel manageable — I knew exactly what was needed at every step and my visa came through in 19 days.",
-      name: "Priya S.",
-      role: "MSc Data Science · University of Manchester",
-      avatar: "PS",
-    },
-    {
-      text: "We were scaling fast and needed to hire three engineers from outside the EU. SoftHire got our Sponsor Licence sorted in under three weeks and managed all three Skilled Worker applications. Game changer for our People team.",
-      name: "James T.",
-      role: "Head of People · Series B Fintech, London",
-      avatar: "JT",
-    },
-    {
-      text: "My sister had a refusal from another agent. SoftHire reviewed her case, identified exactly what went wrong, and we reapplied successfully. The case dashboard meant I could follow every update without chasing anyone.",
-      name: "Chidi O.",
-      role: "LLB Law · University of Coventry",
-      avatar: "CO",
-    },
-  ];
+const whyPillars = [
+  {
+    label: 'IAA-regulated. Accountable advice.',
+    body: 'Immigration advice in the UK is legally restricted. SoftHire is authorised and regulated by the Immigration Advice Authority (IAA) — so the advice you receive is compliant, protected and professionally accountable. Not all providers can say the same.',
+  },
+  {
+    label: 'Built around the employer journey, not the visa application.',
+    body: 'Most immigration services start and end with the applicant. SoftHire is built around you — sponsor licence eligibility, key personnel setup, Certificate of Sponsorship assignment, document tracking, reporting duties and ongoing compliance. The full picture, not just the paperwork.',
+  },
+  {
+    label: 'Fixed fee. No hourly surprises.',
+    body: 'A clear process with fixed-fee support where possible. You know the cost, the steps and the risk points before anything is submitted — not after you\'ve already committed.',
+  },
+  {
+    label: 'Compliance workflows, not just advice.',
+    body: 'Sponsorship fails when information is scattered. SoftHire structures your documents, worker records, visa dates and compliance tasks so they\'re organised, tracked and ready for Home Office scrutiny — not assembled in a panic when a letter arrives.',
+  },
+  {
+    label: 'Sector knowledge that matters.',
+    body: 'We work specifically with care homes, tech startups, restaurants, universities and recruitment agencies. We already know the eligible SOC codes, the salary thresholds, the sector-specific failure points — and how to avoid them.',
+  },
+  {
+    label: 'Beyond the licence. Long-term audit readiness.',
+    body: 'Approval is the start. We help you stay compliant through right-to-work checks, visa expiry tracking, Home Office reporting duties and record-keeping standards — so when UKVI comes, you\'re ready.',
+  },
+];
 
+const industries = [
+  {
+    title: 'Tech Startups',
+    desc: 'Fast hiring cycles, equity-heavy packages and lean HR teams. We build compliance around your pace.',
+    href: '/sponsor-licence-tech-startups',
+  },
+  {
+    title: 'Care Homes',
+    desc: 'CQC registration, Health and Care Worker visas, and the highest Home Office audit risk of any sector. We know what inspectors look for.',
+    href: '/sponsor-licence-care-homes',
+  },
+  {
+    title: 'Construction',
+    desc: 'Project-based contracts, mobile workforces and high turnover create specific sponsorship risks. We help you stay compliant across every site.',
+    href: '/#contact',
+  },
+  {
+    title: 'Foreign Companies Expanding in the UK',
+    desc: 'Bringing your own people into a new UK entity requires a sponsor licence before they can work here. We handle it alongside your incorporation.',
+    href: '/sponsor-licence-for-foreign-companies',
+  },
+  {
+    title: 'Education Providers',
+    desc: 'Education providers managing international students, sponsored staff, visa records and immigration compliance responsibilities. We manage both compliance regimes so your institution stays audit-ready.',
+    href: '/sponsor-licence-universities',
+  },
+];
+
+const processSteps = [
+  { num: '01', title: 'Assess', desc: 'We check whether your business and role are suitable.' },
+  { num: '02', title: 'Prepare', desc: 'We collect documents and structure the application.' },
+  { num: '03', title: 'Submit', desc: 'We support the sponsor licence or visa submission.' },
+  { num: '04', title: 'Sponsor', desc: 'We help with CoS and Skilled Worker applications.' },
+  { num: '05', title: 'Comply', desc: 'We help you stay audit-ready after approval.' },
+];
+
+const pricingCards = [
+  {
+    title: 'Sponsor Licence',
+    price: 'From £1,500',
+    unit: 'Fixed fee',
+    items: [
+      'Eligibility assessment',
+      'Document preparation',
+      'SMS application submission',
+      'Home Office query handling',
+      'Includes key personnel setup',
+      'Priority processing available — 10 working days',
+    ],
+    cta: 'Get a quote',
+    ctaHref: '/#contact',
+    ctaTrack: 'pricing_sponsor_licence_quote',
+    highlight: false,
+  },
+  {
+    title: 'Skilled Worker Visa',
+    price: 'From £800',
+    unit: 'Per application',
+    items: [
+      'Certificate of Sponsorship assignment',
+      'Visa application support',
+      'Document review',
+      'Pre-submission eligibility check',
+      'In-country and overseas routes',
+      'Requires active sponsor licence',
+    ],
+    cta: 'Get a quote',
+    ctaHref: '/#contact',
+    ctaTrack: 'pricing_skilled_worker_quote',
+    highlight: true,
+  },
+  {
+    title: 'Compliance Retainer',
+    price: 'From £300',
+    unit: '/month',
+    items: [
+      'Right-to-work record management',
+      'Visa expiry tracking',
+      'Home Office reporting duties',
+      'Audit readiness reviews',
+      'Ongoing sponsor duty guidance',
+      'Cancel any time — no lock-in',
+    ],
+    cta: 'Get a quote',
+    ctaHref: '/#contact',
+    ctaTrack: 'pricing_compliance_retainer_quote',
+    highlight: false,
+  },
+];
+
+const testimonials = [
+  {
+    text: 'We needed a sponsor licence for our care home in under six weeks. SoftHire handled everything — the application was approved first time with no queries from the Home Office.',
+    name: 'Registered Manager',
+    role: 'Residential care home, West Midlands',
+    avatar: 'RM',
+  },
+  {
+    text: 'As a tech startup with no dedicated HR team, we had no idea where to start. SoftHire gave us a clear process, fixed costs, and our licence was approved on the first application.',
+    name: 'Co-Founder',
+    role: 'Series A technology company, London',
+    avatar: 'CF',
+  },
+  {
+    text: 'We were expanding our headquarters to the UK and needed to bring three senior employees across. SoftHire handled the sponsor licence and all three visa applications simultaneously — no delays, no surprises.',
+    name: 'Head of People',
+    role: 'International technology company',
+    avatar: 'HP',
+  },
+];
+
+const About = () => {
   return (
     <>
-      {/* TRUST STATS */}
-      <section id="about" className="py-24 relative overflow-hidden" style={{ background: '#0E1F45' }}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-14">
+      {/* SECTION 4 — WHY EMPLOYERS CHOOSE SOFTHIRE */}
+      <section id="why-softhire" className="py-24 relative overflow-hidden" style={{ background: '#0E1F45' }}>
+        <div className="absolute top-0 left-0 w-96 h-96 rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(46,100,200,0.10) 0%, transparent 70%)' }} aria-hidden="true" />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+          <div className="mb-14">
             <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Why SoftHire</p>
-            <h2 className="text-white font-bold leading-tight tracking-tight" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
-              Built for the<br />
-              <span className="text-amber-400">moments that matter.</span>
+            <h2 className="text-white font-bold leading-tight tracking-tight mb-4" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
+              Why employers choose SoftHire
             </h2>
-            <p className="text-white/60 text-base leading-relaxed mt-3 max-w-xl mx-auto">
-              A UK visa application is not just paperwork. It is your career, your education, your family. We treat it that way.
+            <p className="text-white/60 text-base leading-relaxed max-w-2xl">
+              Sponsoring international workers isn't just a visa process — it's a compliance system. Getting the licence is step one. Maintaining it is the job. SoftHire handles both.
             </p>
           </div>
-
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-20">
-            {trustStats.map(({ icon, num, label }) => (
-              <div
-                key={num}
-                className="rounded-2xl border border-white/10 p-6 flex flex-col transition-all duration-300 hover:border-amber-400/25 hover:-translate-y-1"
-                style={{ background: '#172859' }}
-              >
-                <span className="text-3xl mb-3" aria-hidden="true">{icon}</span>
-                <span className="text-amber-400 font-extrabold text-3xl leading-none mb-2" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>{num}</span>
-                <span className="text-white/55 text-sm leading-relaxed">{label}</span>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {whyPillars.map((p) => (
+              <div key={p.label} className="rounded-2xl border border-white/10 p-6 flex flex-col gap-3 hover:border-amber-400/25 hover:-translate-y-1 transition-all duration-300" style={{ background: '#172859' }}>
+                <span className="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0" aria-hidden="true" />
+                <h3 className="text-white font-bold text-base leading-snug" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>{p.label}</h3>
+                <p className="text-white/60 text-sm leading-relaxed">{p.body}</p>
               </div>
             ))}
-          </div>
-
-          {/* About text */}
-          <div className="grid lg:grid-cols-2 gap-12 mb-20">
-            <div>
-              <h3 className="text-white font-bold text-2xl mb-4" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>About SoftHire</h3>
-              <p className="text-white/65 leading-relaxed mb-5">
-                At SoftHire, we make global hiring <strong className="text-white">simple, compliant, and fast</strong>. We help UK businesses unlock access to international talent by streamlining every step — from applying for a sponsor licence, to staying compliant with Home Office rules, to recruiting skilled workers from around the world.
-              </p>
-              <p className="text-white/65 leading-relaxed">
-                We also help deserving candidates who want to bring their skills to the UK by assisting them through every visa type — from Student Visas and Graduate Visas to Skilled Worker Visas, Dependant Visas, and beyond.
-              </p>
-            </div>
-            <div>
-              <h3 className="text-white font-bold text-2xl mb-4" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>Our Mission</h3>
-              <div className="flex flex-col gap-3">
-                {[
-                  "Enable businesses to hire the best people, wherever they are.",
-                  "Simplify compliance with smart, automated tools.",
-                  "Bridge global talent gaps so the UK remains competitive in a fast-changing world.",
-                ].map((point) => (
-                  <div key={point} className="flex items-start gap-3 bg-white/5 rounded-xl px-4 py-3 border border-white/8">
-                    <span className="w-2 h-2 rounded-full bg-amber-400 flex-shrink-0 mt-1.5" aria-hidden="true" />
-                    <p className="text-white/70 text-sm leading-relaxed">{point}</p>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-6 p-4 rounded-xl border border-amber-400/20 bg-amber-400/5">
-                <p className="text-white/80 text-sm">
-                  Considering recruiting internationally?{" "}
-                  <a href="#contact" className="text-amber-400 hover:text-amber-300 font-semibold transition-colors">Get in touch</a>.
-                </p>
-              </div>
-            </div>
           </div>
         </div>
       </section>
 
-      {/* TESTIMONIALS */}
-      <section className="py-24 relative overflow-hidden" style={{ background: '#0B1736' }}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-14">
-            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">What People Say</p>
+      {/* SECTION 5 — INDUSTRIES */}
+      <section id="industries" className="py-24 relative overflow-hidden" style={{ background: '#0B1736' }}>
+        <div className="absolute bottom-0 right-0 w-96 h-96 rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(232,168,48,0.07) 0%, transparent 70%)' }} aria-hidden="true" />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+          <div className="mb-12">
+            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Industries We Support</p>
+            <h2 className="text-white font-bold leading-tight tracking-tight mb-3" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
+              Sector knowledge<br />
+              <span className="text-amber-400">that matters.</span>
+            </h2>
+            <p className="text-white/60 text-base leading-relaxed max-w-2xl">
+              SoftHire supports UK employers and institutions where international hiring, sponsorship and immigration compliance need to be managed carefully.
+            </p>
+          </div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {industries.map((ind) => (
+              <div key={ind.title} className="rounded-2xl border border-white/10 p-6 flex flex-col gap-4 hover:border-amber-400/25 hover:-translate-y-1 transition-all duration-300" style={{ background: '#0E1F45' }}>
+                <h3 className="text-white font-bold text-lg leading-snug" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>{ind.title}</h3>
+                <p className="text-white/60 text-sm leading-relaxed flex-grow">{ind.desc}</p>
+                <a
+                  href={ind.href}
+                  className="inline-flex items-center gap-2 text-amber-400 hover:text-amber-300 text-sm font-semibold transition-colors mt-auto"
+                  aria-label={`Learn more about ${ind.title}`}
+                >
+                  Learn more <ArrowRight className="h-3.5 w-3.5" />
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* SECTION 6 — PROCESS */}
+      <section id="how-it-works" className="py-24 relative overflow-hidden" style={{ background: '#0E1F45' }}>
+        <div className="absolute top-0 left-0 w-96 h-96 rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(46,100,200,0.12) 0%, transparent 70%)' }} aria-hidden="true" />
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+          <div className="mb-12">
+            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Our Process</p>
             <h2 className="text-white font-bold leading-tight tracking-tight" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
-              Real people.<br />
-              <span className="text-amber-400">Real journeys.</span>
+              From first call to<br />
+              <span className="text-amber-400">fully compliant.</span>
             </h2>
           </div>
-
-          <div className="grid md:grid-cols-3 gap-5">
-            {testimonials.map((t) => (
-              <article
-                key={t.name}
-                className="rounded-2xl border border-white/10 p-6 flex flex-col transition-all duration-300 hover:border-amber-400/25 hover:-translate-y-1"
-                style={{ background: '#172859' }}
-                itemScope
-                itemType="https://schema.org/Review"
+          <div className="flex flex-col">
+            {processSteps.map((step, i) => (
+              <div
+                key={step.num}
+                className={`flex gap-6 py-6 group transition-all duration-200 hover:pl-2 ${i < processSteps.length - 1 ? 'border-b border-white/10' : ''}`}
               >
-                <meta itemProp="itemReviewed" content="SoftHire" />
-                <div className="text-amber-400 text-5xl font-extrabold leading-none opacity-20 mb-3" aria-hidden="true">"</div>
-                <div className="text-amber-400 text-sm mb-3" aria-label="5 out of 5 stars">
-                  <span itemProp="reviewRating" itemScope itemType="https://schema.org/Rating">
-                    <meta itemProp="ratingValue" content="5" />
-                    <meta itemProp="bestRating" content="5" />
-                    ★★★★★
-                  </span>
+                <div className="w-10 h-10 rounded-full border border-amber-400/30 flex items-center justify-center flex-shrink-0 mt-0.5 text-amber-400 text-xs font-bold group-hover:bg-amber-400 group-hover:border-amber-400 transition-all duration-200" style={{ fontFamily: "'Syne', sans-serif" }}>
+                  <span style={{ color: 'inherit' }}>{step.num}</span>
                 </div>
-                <p className="text-white/75 text-sm leading-relaxed flex-grow mb-5" itemProp="reviewBody">{t.text}</p>
-                <div className="flex items-center gap-3" itemProp="author" itemScope itemType="https://schema.org/Person">
-                  <div className="w-10 h-10 rounded-full bg-amber-400/20 border border-amber-400/20 flex items-center justify-center text-amber-400 text-xs font-bold flex-shrink-0">
-                    {t.avatar}
-                  </div>
-                  <div>
-                    <div className="text-white font-semibold text-sm" itemProp="name">{t.name}</div>
-                    <div className="text-white/45 text-xs">{t.role}</div>
-                  </div>
+                <div>
+                  <h3 className="text-white font-bold text-lg mb-1">{step.title}</h3>
+                  <p className="text-white/55 text-sm leading-relaxed">{step.desc}</p>
                 </div>
-              </article>
+              </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* SECTION 7 — PRICING */}
+      <section id="pricing" className="py-24 relative overflow-hidden" style={{ background: '#0B1736' }}>
+        <div className="absolute top-0 right-0 w-96 h-96 rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(232,168,48,0.07) 0%, transparent 70%)' }} aria-hidden="true" />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+          <div className="mb-12">
+            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Pricing</p>
+            <h2 className="text-white font-bold leading-tight tracking-tight mb-3" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
+              Transparent pricing.<br />
+              <span className="text-amber-400">No hourly surprises.</span>
+            </h2>
+            <p className="text-white/60 text-base leading-relaxed max-w-xl">
+              Know the cost, the steps and the risk points before anything is submitted.
+            </p>
+          </div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {pricingCards.map((card) => (
+              <div
+                key={card.title}
+                className={`rounded-2xl border p-7 flex flex-col transition-all duration-300 hover:-translate-y-1 ${card.highlight ? 'border-amber-400/50' : 'border-white/10'}`}
+                style={{ background: card.highlight ? 'linear-gradient(135deg, #1a3a8f, #172859)' : '#172859' }}
+              >
+                {card.highlight && (
+                  <span className="inline-block bg-amber-400 text-[#0B1736] text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-full mb-4 w-fit">Most popular</span>
+                )}
+                <p className="text-amber-400 text-xs font-semibold uppercase tracking-wider mb-2">{card.title}</p>
+                <div className="flex items-end gap-1 mb-1">
+                  <span className="text-white font-extrabold text-3xl leading-none" style={{ fontFamily: "'Syne', sans-serif" }}>{card.price}</span>
+                </div>
+                <p className="text-white/50 text-sm mb-6">{card.unit}</p>
+                <ul className="flex flex-col gap-2.5 flex-grow mb-7">
+                  {card.items.map((item) => (
+                    <li key={item} className="flex items-start gap-2.5 text-white/65 text-sm">
+                      <span className="w-1.5 h-1.5 rounded-full bg-teal-400 flex-shrink-0 mt-1.5" aria-hidden="true" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+                <a
+                  href={card.ctaHref}
+                  className={`inline-flex items-center justify-center gap-2 font-semibold text-sm px-5 py-3 rounded-full transition-all duration-200 ${card.highlight ? 'bg-amber-400 hover:bg-amber-300 text-[#0B1736]' : 'bg-white/8 hover:bg-white/15 text-white border border-white/20'}`}
+                  onClick={() => trackCTAClick(card.ctaTrack, 'pricing_section')}
+                >
+                  {card.cta} <ArrowRight className="h-4 w-4" />
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* SECTION 8 — TRUST AND REGULATION */}
+      <section id="trust" className="py-24 relative overflow-hidden" style={{ background: '#0E1F45' }}>
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+
+          {/* Opening line */}
+          <div className="mb-14 max-w-3xl">
+            <p className="text-white/80 text-xl leading-relaxed font-light">
+              You're not just hiring an immigration service. You're trusting someone with your{' '}
+              <span className="text-white font-semibold">licence to operate.</span>
+            </p>
+          </div>
+
+          {/* IAA Regulation block */}
+          <div className="rounded-2xl border border-amber-400/20 p-8 mb-10" style={{ background: 'rgba(232,168,48,0.04)' }}>
+            <div className="flex items-start gap-4 mb-6">
+              <ShieldCheck className="h-8 w-8 text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+              <div>
+                <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-1">IAA Regulation</p>
+                <h3 className="text-white font-bold text-xl" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>Authorised and regulated by the Immigration Advice Authority</h3>
+              </div>
+            </div>
+            <p className="text-white/65 text-base leading-relaxed max-w-3xl mb-8">
+              Immigration advice in the UK is a legally restricted activity. Only authorised individuals and organisations can provide it lawfully. SoftHire is IAA-regulated — meaning our advice is professionally accountable, our conduct is governed by a statutory framework, and you have formal recourse if something goes wrong. Many providers operating in this space are not regulated. That matters.
+            </p>
+            <div className="grid sm:grid-cols-3 gap-6">
+              {[
+                { symbol: '✦', heading: 'Professional accountability', body: 'We operate under a statutory code of conduct. Every piece of advice we give is regulated.' },
+                { symbol: '✦', heading: 'Formal complaints process', body: 'If something goes wrong, you have recourse to the Immigration Advice Authority — an independent statutory body.' },
+                { symbol: '✦', heading: 'Legal protection', body: 'Regulated advice carries professional indemnity coverage. Unregulated advice does not.' },
+              ].map((col) => (
+                <div key={col.heading} className="rounded-xl border border-white/10 p-5" style={{ background: 'rgba(255,255,255,0.03)' }}>
+                  <p className="text-amber-400 text-lg mb-2" aria-hidden="true">{col.symbol}</p>
+                  <h4 className="text-white font-semibold text-sm mb-2">{col.heading}</h4>
+                  <p className="text-white/55 text-sm leading-relaxed">{col.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Founder credibility */}
+          <div className="rounded-2xl border border-white/10 p-8 mb-10" style={{ background: '#172859' }}>
+            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Founder Credibility</p>
+            <h3 className="text-white font-bold text-xl mb-3" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>Founded by a lawyer.</h3>
+            <p className="text-white/65 text-base leading-relaxed max-w-3xl">
+              SoftHire was built by an Oxford-trained, IAA-regulated solicitor with a decade of transactional legal experience across international law firms and financial institutions. We understand compliance because we've lived it — on both sides of the table.
+            </p>
+          </div>
+
+          {/* Testimonials */}
+          <div className="mb-12">
+            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">What Clients Say</p>
+            <h3 className="text-white font-bold text-2xl mb-8" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>
+              Real cases.<br /><span className="text-amber-400">Real results.</span>
+            </h3>
+            <div className="grid md:grid-cols-3 gap-5">
+              {testimonials.map((t) => (
+                <article
+                  key={t.avatar}
+                  className="rounded-2xl border border-white/10 p-6 flex flex-col transition-all duration-300 hover:border-amber-400/25 hover:-translate-y-1"
+                  style={{ background: '#172859' }}
+                  itemScope
+                  itemType="https://schema.org/Review"
+                >
+                  <meta itemProp="itemReviewed" content="SoftHire" />
+                  <div className="text-amber-400 text-5xl font-extrabold leading-none opacity-20 mb-3" aria-hidden="true">"</div>
+                  <div className="text-amber-400 text-sm mb-3" aria-label="5 out of 5 stars">
+                    <span itemProp="reviewRating" itemScope itemType="https://schema.org/Rating">
+                      <meta itemProp="ratingValue" content="5" />
+                      <meta itemProp="bestRating" content="5" />
+                      ★★★★★
+                    </span>
+                  </div>
+                  <p className="text-white/75 text-sm leading-relaxed flex-grow mb-5" itemProp="reviewBody">{t.text}</p>
+                  <div className="flex items-center gap-3" itemProp="author" itemScope itemType="https://schema.org/Person">
+                    <div className="w-10 h-10 rounded-full bg-amber-400/20 border border-amber-400/20 flex items-center justify-center text-amber-400 text-xs font-bold flex-shrink-0">
+                      {t.avatar}
+                    </div>
+                    <div>
+                      <div className="text-white font-semibold text-sm" itemProp="name">{t.name}</div>
+                      <div className="text-white/45 text-xs">{t.role}</div>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          {/* Data & Confidentiality + Response Commitment */}
+          <div className="grid md:grid-cols-2 gap-6 mb-14">
+            <div className="rounded-2xl border border-white/10 p-7" style={{ background: '#172859' }}>
+              <h4 className="text-white font-bold text-base mb-3">Data &amp; Confidentiality</h4>
+              <p className="text-white/60 text-sm leading-relaxed">
+                Your data is handled with the same rigour we apply to your case. All client information is processed in accordance with UK GDPR. Documents shared with SoftHire are stored securely and never passed to third parties without your explicit consent. Immigration matters involve sensitive personal data — we treat them accordingly.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/10 p-7" style={{ background: '#172859' }}>
+              <h4 className="text-white font-bold text-base mb-3">Response Commitment</h4>
+              <p className="text-white/60 text-sm leading-relaxed">
+                We respond to all new enquiries within 24 hours. You'll speak directly with a regulated adviser — not a call centre, not an automated triage system. If your situation is urgent, tell us and we'll prioritise accordingly.
+              </p>
+            </div>
+          </div>
+
+          {/* Closing CTA */}
+          <div
+            className="rounded-2xl p-10 text-center relative overflow-hidden"
+            style={{ background: 'linear-gradient(135deg, #1a3a8f 0%, #0B1736 50%, #1a3a8f 100%)', border: '1px solid rgba(232,168,48,0.2)' }}
+          >
+            <div className="absolute inset-0 pointer-events-none" style={{ background: 'radial-gradient(circle at 50% 50%, rgba(232,168,48,0.08) 0%, transparent 70%)' }} aria-hidden="true" />
+            <div className="relative z-10">
+              <h3 className="text-white font-bold text-2xl md:text-3xl mb-3" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>Ready to get started?</h3>
+              <p className="text-white/60 text-base mb-8 max-w-lg mx-auto">
+                Book a free consultation. We'll assess your situation, explain your options and confirm your next steps — all within 24 hours. No commitment required.
+              </p>
+              <a
+                href="/#contact"
+                className="inline-flex items-center gap-2 bg-amber-400 hover:bg-amber-300 font-semibold px-8 py-4 rounded-full transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                style={{ color: '#0B1736' }}
+                onClick={() => trackCTAClick('book_free_consultation', 'closing_cta')}
+              >
+                Book Free Consultation
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
           </div>
         </div>
       </section>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -64,13 +64,13 @@ const Contact = () => {
         <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6 relative z-10">
           <div>
             <h2 className="text-white font-bold leading-tight tracking-tight" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(1.6rem, 3vw, 2.4rem)' }}>
-              Ready to start your UK visa journey?
+              Ready to get your sponsor licence?
             </h2>
             <p className="text-white/60 mt-2 text-base">Free consultation. No commitment. Clear next steps in 24 hours.</p>
           </div>
           <div className="flex flex-wrap gap-3 flex-shrink-0">
-            <a href="#contact" className="inline-flex items-center gap-2 bg-amber-400 hover:bg-amber-300 text-navy-900 font-semibold px-7 py-3.5 rounded-full transition-all duration-200 hover:-translate-y-0.5 whitespace-nowrap" style={{ color: '#0B1736' }} onClick={() => trackCTAClick('book_free_call', 'cta_strip')}>
-              Book a free call <ArrowRight className="h-4 w-4" />
+            <a href="#contact" className="inline-flex items-center gap-2 bg-amber-400 hover:bg-amber-300 text-navy-900 font-semibold px-7 py-3.5 rounded-full transition-all duration-200 hover:-translate-y-0.5 whitespace-nowrap" style={{ color: '#0B1736' }} onClick={() => trackCTAClick('book_sponsor_assessment', 'cta_strip')}>
+              Book a sponsor licence assessment <ArrowRight className="h-4 w-4" />
             </a>
             <a href="https://wa.me/00447585198493" rel="noopener noreferrer" target="_blank" className="inline-flex items-center gap-2 bg-white/8 hover:bg-white/15 text-white border border-white/20 font-semibold px-7 py-3.5 rounded-full transition-all duration-200 hover:-translate-y-0.5 whitespace-nowrap" onClick={() => trackContactLinkClick('whatsapp')}>
               WhatsApp us

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,5 @@
-import { ArrowRight, CheckCircle } from 'lucide-react';
-import { trackCTAClick, trackNavClick } from '../lib/analytics';
-import BookMeetingButton from './BookMeetingButton';
+import { ArrowRight, CheckCircle, ShieldCheck } from 'lucide-react';
+import { trackCTAClick } from '../lib/analytics';
 
 const Hero = () => {
   return (
@@ -32,70 +31,51 @@ const Hero = () => {
             {/* Eyebrow */}
             <p className="flex items-center gap-3 text-amber-400 text-sm font-semibold uppercase tracking-widest mb-6">
               <span className="block w-6 h-px bg-amber-400" aria-hidden="true" />
-              UK-Regulated Global Mobility
+              UK Employer Immigration Support
             </p>
 
-            <h1 id="hero-heading" className="font-bold text-white leading-tight tracking-tight mb-6" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2.8rem, 6vw, 5.5rem)' }}>
-              UK visas.<br />
-              Handled by <span className="text-amber-400">experts.</span><br />
-              Powered by <span className="text-teal-400">technology.</span>
+            <h1 id="hero-heading" className="font-bold text-white leading-tight tracking-tight mb-6" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2.2rem, 4.5vw, 4rem)' }}>
+              Sponsor licence and Skilled Worker compliance support for{' '}
+              <span className="text-amber-400">UK employers</span>
             </h1>
 
             <p className="text-lg text-white/70 leading-relaxed mb-8 max-w-xl font-light">
-              SoftHire is the UK's smartest immigration service — IAA-regulated visa support for international students, employers hiring global talent, and anyone navigating the UK system.
+              SoftHire helps UK businesses secure sponsor licences, manage Skilled Worker sponsorship, and stay audit-ready with fixed-fee immigration support and structured compliance workflows.
             </p>
 
-            {/* Yoshki Certified Partner */}
-            <div className="flex items-center gap-3 mb-8 bg-white/5 backdrop-blur-sm rounded-xl px-4 py-3 border border-white/10 w-fit">
-              <div style={{ width: '28px', flexShrink: 0 }}>
-                <div style={{ position: 'relative', paddingBottom: '152%', height: 0, overflow: 'hidden' }}>
-                  <iframe
-                    src="https://cdn2.yoshki.com/badgeframe?10"
-                    title="Yoshki Certified Partner Badge"
-                    style={{
-                      overflow: 'hidden', border: '0px', margin: '0px', padding: '0px',
-                      backgroundColor: 'transparent', top: '0px', left: '0px',
-                      width: '100%', height: '100%', position: 'absolute',
-                    }}
-                  />
-                </div>
-              </div>
-              <span className="text-white/80 text-sm font-medium">Yoshki Certified Partner</span>
-            </div>
-
             {/* CTAs */}
-            <div className="flex flex-wrap gap-4 mb-10">
+            <div className="flex flex-wrap gap-4 mb-8">
               <a
                 href="/#contact"
-                className="inline-flex items-center gap-2 bg-amber-400 hover:bg-amber-300 text-navy-900 font-semibold text-base px-7 py-3.5 rounded-full transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                className="inline-flex items-center gap-2 bg-amber-400 hover:bg-amber-300 font-semibold text-base px-7 py-3.5 rounded-full transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
                 style={{ color: '#0B1736' }}
-                onClick={() => trackCTAClick('start_your_journey', 'hero')}
+                onClick={() => trackCTAClick('book_sponsor_licence_assessment', 'hero')}
               >
-                Start your journey
+                Book a sponsor licence assessment
                 <ArrowRight className="h-4 w-4" />
               </a>
-              <BookMeetingButton
-                location="hero_homepage"
-                label="Book a free call"
-                className="inline-flex items-center gap-2 bg-white/10 hover:bg-white/20 text-white font-semibold text-base px-7 py-3.5 rounded-full transition-all duration-200 border border-white/20"
-              />
               <a
-                href="/#how-it-works"
-                className="inline-flex items-center gap-2 text-white/60 hover:text-white text-base font-medium transition-colors duration-200"
-                onClick={() => trackNavClick('see_how_it_works_hero')}
+                href="/sponsor-licence-application"
+                className="inline-flex items-center gap-2 bg-white/10 hover:bg-white/20 text-white font-semibold text-base px-7 py-3.5 rounded-full transition-all duration-200 border border-white/20"
+                onClick={() => trackCTAClick('check_business_can_sponsor', 'hero')}
               >
-                <span className="w-7 h-7 rounded-full border border-white/30 flex items-center justify-center text-xs" aria-hidden="true">▶</span>
-                See how it works
+                Check if your business can sponsor workers
               </a>
+            </div>
+
+            {/* IAA trust line */}
+            <div className="flex items-center gap-3 mb-8">
+              <ShieldCheck className="h-5 w-5 text-teal-400 flex-shrink-0" aria-hidden="true" />
+              <span className="text-white/60 text-sm">IAA-regulated immigration advice</span>
             </div>
 
             {/* Trust badges */}
             <div className="flex flex-wrap gap-3">
               {[
-                'IAA Regulated',
-                'University Trusted',
+                'Sponsor Licence Applications',
+                'Skilled Worker Visas',
+                'Compliance Retainers',
                 'Fixed Fees',
-                'Student Specialists',
               ].map((badge) => (
                 <span
                   key={badge}
@@ -110,20 +90,20 @@ const Hero = () => {
 
           {/* Right: Stats panel */}
           <div className="hidden lg:flex flex-col gap-4 items-end">
-            {/* 97% badge */}
+            {/* IAA badge */}
             <div
-              className="text-center px-6 py-5 rounded-2xl text-navy-900 font-bold shadow-2xl"
-              style={{ background: 'linear-gradient(135deg, #E8A830, #D4920A)' }}
-              aria-label="97 percent UK visa success rate"
+              className="text-center px-6 py-5 rounded-2xl font-bold shadow-2xl"
+              style={{ background: 'linear-gradient(135deg, #E8A830, #D4920A)', color: '#0B1736' }}
+              aria-label="IAA regulated immigration advice"
             >
-              <span className="block text-4xl font-extrabold leading-none">97%</span>
-              <span className="text-sm mt-1 block opacity-80">Visa Success Rate</span>
+              <span className="block text-3xl font-extrabold leading-none">IAA</span>
+              <span className="text-sm mt-1 block opacity-80">Regulated Advice</span>
             </div>
 
             {[
-              { num: '2,400+', label: 'Students reached the UK with SoftHire' },
-              { num: '3 wks', label: 'Average time contact-to-submission' },
-              { num: 'IAA', label: 'UK Immigration Advice Authority regulated' },
+              { num: 'Fixed Fee', label: 'Transparent pricing — know your costs before you commit' },
+              { num: '24 hrs', label: 'Response commitment for all new enquiries' },
+              { num: '1st time', label: 'Applications prepared for first-time approval' },
             ].map(({ num, label }) => (
               <div
                 key={num}
@@ -134,16 +114,16 @@ const Hero = () => {
               </div>
             ))}
 
-            {/* Feature checklist */}
+            {/* Compliance checklist */}
             <div className="w-full bg-white/5 border border-white/10 rounded-2xl px-6 py-5 backdrop-blur-sm mt-2">
-              <p className="text-white/60 text-xs uppercase tracking-wider mb-3 font-semibold">All Visa Types Supported</p>
+              <p className="text-white/60 text-xs uppercase tracking-wider mb-3 font-semibold">Employer Services</p>
               {[
-                'UK Student Visa',
-                'Graduate Visa',
-                'Skilled Worker Visa',
-                'Dependant Visa',
-                'Sponsor Licence',
+                'Sponsor Licence Application',
+                'Skilled Worker Visa Support',
+                'Certificate of Sponsorship',
+                'Right-to-Work Checks',
                 'Compliance Retainer',
+                'Home Office Audit Readiness',
               ].map((v) => (
                 <div key={v} className="flex items-center gap-2 text-white/70 text-sm py-1">
                   <CheckCircle className="h-4 w-4 text-teal-400 flex-shrink-0" />

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,79 +1,105 @@
-﻿import { useState } from 'react';
-import { ArrowRight } from 'lucide-react';
-import { trackVisaFilter, trackVisaCardClick } from '../lib/analytics';
+﻿import { ArrowRight } from 'lucide-react';
+import { trackCTAClick } from '../lib/analytics';
 
-type FilterType = 'all' | 'students' | 'employers' | 'employees';
-
-interface VisaCard {
-  type: string;
-  name: string;
-  desc: string;
-  price: string;
-  categories: FilterType[];
-  link: string;
-}
-
-const visaCards: VisaCard[] = [
-  { type: 'Students', name: 'UK Student Visa', desc: 'Full-service application management from CAS number to biometrics. We work with students applying from anywhere in the world.', price: 'From £299 fixed fee', categories: ['students'], link: '#contact' },
-  { type: 'Students + Partners', name: 'Dependant Visa', desc: 'Bring your partner or family to the UK alongside your student visa. Bundled with your main application for a seamless process.', price: 'From £249 per dependant', categories: ['students'], link: '#contact' },
-  { type: 'Post-Study', name: 'Graduate Visa', desc: 'Stay in the UK and work for 2 years after graduation. We handle this for existing clients at near-zero effort.', price: 'From £199 fixed fee', categories: ['students'], link: '#contact' },
-  { type: 'Employers', name: 'Sponsor Licence', desc: 'Get your UK Sponsor Licence so you can hire international talent. Our gateway product — everything else follows from this.', price: 'From £1,500 fixed fee', categories: ['employers'], link: '#contact' },
-  { type: 'Employers + Employees', name: 'Skilled Worker Visa', desc: 'End-to-end management of Skilled Worker Visa applications for each sponsored employee. Trackable, transparent, fast.', price: 'From £800 per application', categories: ['employers', 'employees'], link: '#contact' },
-  { type: 'Employees', name: 'Certificate of Sponsorship', desc: 'Expert guidance on Certificate of Sponsorship requirements, ensuring your COS is issued correctly and on time.', price: 'Included with Skilled Worker', categories: ['employees'], link: '#contact' },
-  { type: 'Employers — Ongoing', name: 'Compliance Retainer', desc: 'Stay audit-ready with ongoing sponsor licence compliance management — reporting duties, visa expiry alerts, and document management.', price: 'From £300/month', categories: ['employers'], link: '#contact' },
-  { type: 'Personal', name: 'Personal & Family Visa', desc: 'Support for personal and family visas including spouse, partner, and dependant applications for those joining family in the UK.', price: 'From £249 fixed fee', categories: ['employees'], link: '#contact' },
-];
-
-const filters: { label: string; value: FilterType }[] = [
-  { label: 'All', value: 'all' },
-  { label: 'Students', value: 'students' },
-  { label: 'Employers', value: 'employers' },
-  { label: 'Employees', value: 'employees' },
+const services = [
+  {
+    label: 'Sponsor Licence Applications',
+    heading: 'Apply for a sponsor licence with a clearer, more structured process.',
+    desc: 'SoftHire helps employers assess readiness, gather the right supporting documents, prepare the application, and understand the Home Office compliance expectations before submission.',
+    techHeading: 'How the technology helps:',
+    techItems: [
+      'Guided document collection',
+      'Application progress tracking',
+      'Key personnel checklist',
+      'Evidence management',
+      'Audit-ready application record',
+    ],
+    cta: 'Start your sponsor licence assessment',
+    ctaHref: '/#contact',
+    ctaTrack: 'start_sponsor_licence_assessment',
+  },
+  {
+    label: 'Skilled Worker Sponsorship',
+    heading: 'Sponsor international workers with greater clarity on role eligibility, salary requirements and Certificate of Sponsorship steps.',
+    desc: 'SoftHire helps employers assess whether a role and candidate are suitable for sponsorship, prepare Skilled Worker visa materials, and manage the process from CoS to visa application support.',
+    techHeading: 'How the technology helps:',
+    techItems: [
+      'Role and salary eligibility workflow',
+      'CoS information capture',
+      'Candidate document collection',
+      'Visa timeline tracking',
+      'Centralised worker record',
+    ],
+    cta: 'Check a Skilled Worker role',
+    ctaHref: '/skilled-worker-visa-employer',
+    ctaTrack: 'check_skilled_worker_role',
+  },
+  {
+    label: 'Sponsor Compliance',
+    heading: 'Stay on top of your sponsor duties after the licence is approved.',
+    desc: 'SoftHire helps employers monitor sponsored workers, maintain required records, track visa and right-to-work expiry dates, and prepare for Home Office compliance checks.',
+    techHeading: 'How the technology helps:',
+    techItems: [
+      'Visa and document expiry reminders',
+      'Sponsor duty checklists',
+      'Worker record management',
+      'Compliance task tracking',
+      'Audit trail for key actions',
+    ],
+    cta: 'Book a compliance health check',
+    ctaHref: '/sponsor-licence-compliance',
+    ctaTrack: 'book_compliance_health_check',
+  },
 ];
 
 const Products = () => {
-  const [activeFilter, setActiveFilter] = useState<FilterType>('all');
-  const visible = visaCards.filter((c) => activeFilter === 'all' || c.categories.includes(activeFilter));
-
-  const handleFilterChange = (f: FilterType) => {
-    setActiveFilter(f);
-    trackVisaFilter(f);
-  };
-
   return (
-    <section id="visas" className="py-24 relative overflow-hidden" style={{ background: '#0E1F45' }}>
+    <section id="services" className="py-24 relative overflow-hidden" style={{ background: '#0E1F45' }}>
       <div className="absolute top-0 right-0 w-96 h-96 rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(232,168,48,0.07) 0%, transparent 70%)' }} aria-hidden="true" />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <div className="mb-12">
           <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Our Services</p>
           <h2 className="text-white font-bold leading-tight tracking-tight mb-2" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
-            Every UK visa type.<br /><span className="text-amber-400">One platform.</span>
+            Everything you need to sponsor.<br />
+            <span className="text-amber-400">Nothing you don't.</span>
           </h2>
           <p className="text-white/60 text-base leading-relaxed mt-3 max-w-xl">
-            From first-time student visas to employer sponsor licences — we handle every application end-to-end with fixed fees and no hidden surprises.
+            From first application to ongoing compliance — structured support at every stage of the employer sponsorship journey.
           </p>
         </div>
-        <div className="flex flex-wrap gap-2 mb-10" role="tablist" aria-label="Filter visa types by audience">
-          {filters.map((f) => (
-            <button key={f.value} role="tab" aria-selected={activeFilter === f.value} onClick={() => handleFilterChange(f.value)}
-              className={`text-sm font-medium px-5 py-2 rounded-full border transition-all duration-200 ${activeFilter === f.value ? 'bg-amber-400 border-amber-400 font-semibold' : 'bg-transparent text-white/60 border-white/20 hover:border-amber-400/50 hover:text-white'}`}
-              style={activeFilter === f.value ? { color: '#0B1736' } : {}}>
-              {f.label}
-            </button>
-          ))}
-        </div>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {visible.map((card) => (
-            <article key={card.name} className="rounded-2xl border border-white/10 p-6 flex flex-col transition-all duration-300 hover:border-amber-400/25 hover:-translate-y-1" style={{ background: '#172859' }}>
-              <p className="text-amber-400 text-xs font-semibold uppercase tracking-wider mb-2">{card.type}</p>
-              <h3 className="text-white font-bold text-lg mb-2 leading-snug">{card.name}</h3>
-              <p className="text-white/60 text-sm leading-relaxed flex-grow">{card.desc}</p>
-              <div className="mt-5 pt-4 border-t border-white/10 flex items-center justify-between">
-                <span className="text-white/50 text-xs">{card.price}</span>
-                <a href={card.link} className="inline-flex items-center gap-1.5 text-amber-400 hover:text-amber-300 text-sm font-semibold transition-colors" aria-label={`Get started with ${card.name}`} onClick={() => trackVisaCardClick(card.name)}>
-                  Get started <ArrowRight className="h-3.5 w-3.5" />
-                </a>
+
+        {/* Three cards */}
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {services.map((svc) => (
+            <article
+              key={svc.label}
+              className="rounded-2xl border border-white/10 p-7 flex flex-col transition-all duration-300 hover:border-amber-400/30 hover:-translate-y-1"
+              style={{ background: '#172859' }}
+            >
+              <p className="text-amber-400 text-xs font-semibold uppercase tracking-wider mb-3">{svc.label}</p>
+              <h3 className="text-white font-bold text-base leading-snug mb-3" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>{svc.heading}</h3>
+              <p className="text-white/60 text-sm leading-relaxed mb-5">{svc.desc}</p>
+
+              <div className="border-t border-white/10 pt-5 mb-5 flex-grow">
+                <p className="text-white/50 text-xs font-semibold uppercase tracking-wider mb-3">{svc.techHeading}</p>
+                <ul className="flex flex-col gap-2">
+                  {svc.techItems.map((item) => (
+                    <li key={item} className="flex items-start gap-2 text-white/65 text-sm">
+                      <span className="w-1.5 h-1.5 rounded-full bg-teal-400 flex-shrink-0 mt-1.5" aria-hidden="true" />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
               </div>
+
+              <a
+                href={svc.ctaHref}
+                className="inline-flex items-center gap-2 bg-amber-400/10 hover:bg-amber-400 text-amber-400 hover:text-[#0B1736] font-semibold text-sm px-5 py-2.5 rounded-full transition-all duration-200 border border-amber-400/30 hover:border-amber-400 mt-auto w-fit"
+                onClick={() => trackCTAClick(svc.ctaTrack, 'services_section')}
+              >
+                {svc.cta}
+                <ArrowRight className="h-3.5 w-3.5" />
+              </a>
             </article>
           ))}
         </div>

--- a/src/components/TalentSection.tsx
+++ b/src/components/TalentSection.tsx
@@ -1,85 +1,21 @@
-﻿import { CheckCircle } from 'lucide-react';
-
-const serveCards = [
-  {
-    tag: 'For Students',
-    title: 'Got your UK university offer? We will get you there.',
-    desc: 'Specialist support for international students navigating the UK Student Visa — from document checklist to biometrics to arrival, wherever you are applying from.',
-    items: ['UK Student Visa — worldwide applicants welcome', 'Partner & Dependant Visa add-on', 'Post-study Graduate Visa', 'Fixed fee — know what you will pay'],
-    img: 'https://images.unsplash.com/photo-1523240795612-9a054b0db644?w=600&q=80&fit=crop&crop=top',
-    imgAlt: 'International students at a UK university campus',
-  },
-  {
-    tag: 'For Employers',
-    title: 'Hire globally. Leave the visa to us.',
-    desc: 'We help UK businesses — from startups to established universities — obtain Sponsor Licences and manage every Skilled Worker Visa application.',
-    items: ['Sponsor Licence applications', 'Skilled Worker Visa management', 'Ongoing compliance retainer', 'University & institution partnerships'],
-    img: 'https://images.unsplash.com/photo-1600880292203-757bb62b4baf?w=600&q=80&fit=crop&crop=top',
-    imgAlt: 'Diverse employer team in a UK office',
-  },
-  {
-    tag: 'For Employees',
-    title: 'Relocating to the UK? Focus on your new role.',
-    desc: 'Your employer is sponsoring you — but you still need your visa handled correctly. We manage every step end-to-end so you can focus on what comes next.',
-    items: ['Skilled Worker Visa applications', 'Certificate of Sponsorship guidance', 'Family & dependant applications', 'Right to work verification'],
-    img: 'https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?w=600&q=80&fit=crop&crop=top',
-    imgAlt: 'Professional preparing to relocate to the UK',
-  },
-];
-
-const steps = [
-  { num: '01', title: 'Tell us your situation', desc: 'Answer a few smart questions and our system identifies exactly which UK visa you need and what it will cost — no ambiguity, no jargon.' },
-  { num: '02', title: 'Upload your documents', desc: 'Our platform tells you exactly what you need. Upload securely, and we check everything — flagging issues before they reach the Home Office.' },
-  { num: '03', title: 'We build your application', desc: 'Our advisers prepare and review your complete application pack. AI handles the repetition; humans handle the legal judgement.' },
-  { num: '04', title: 'Track it in real time', desc: 'No more chasing emails. Your case dashboard shows exactly where your application is — every step, every status update, in real time.' },
-];
-
-const TalentSection = () => {
+﻿const TalentSection = () => {
   return (
     <>
-      {/* WHO WE SERVE */}
-      <section id="who-we-help" className="py-24 relative overflow-hidden" style={{ background: '#0B1736' }}>
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mb-14">
-            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">Who We Help</p>
-            <h2 className="text-white font-bold leading-tight tracking-tight" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
-              UK visa support.<br />
-              <span className="text-amber-400">For everyone going places.</span>
-            </h2>
-            <p className="text-white/60 text-base leading-relaxed mt-3 max-w-2xl">
-              Whether you are a student with a UK university offer, an employer scaling globally, or an employee starting a new chapter — SoftHire handles every UK visa application end-to-end.
+      {/* SECTION 2 — PROBLEM FRAMING */}
+      <section id="why-sponsor" className="py-24 relative overflow-hidden" style={{ background: '#0B1736' }}>
+        <div className="absolute top-[-150px] right-[-150px] w-[500px] h-[500px] rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(232,168,48,0.07) 0%, transparent 70%)' }} aria-hidden="true" />
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+          <h2 className="font-bold text-white leading-tight tracking-tight mb-6" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(1.8rem, 4vw, 3rem)' }}>
+            You found the right person.<br />
+            <span className="text-amber-400">Now comes the hard part.</span>
+          </h2>
+          <div className="text-white/65 text-lg leading-relaxed space-y-5">
+            <p>
+              Hiring internationally requires a sponsor licence, compliant HR systems, accurate records, Certificates of Sponsorship, right-to-work checks and ongoing Home Office reporting. A mistake at any stage can mean delays, refusals, or losing your licence entirely.
             </p>
-          </div>
-
-          <div className="grid md:grid-cols-3 gap-1 rounded-2xl overflow-hidden border border-white/10">
-            {serveCards.map((card) => (
-              <div
-                key={card.tag}
-                className="flex flex-col p-8 transition-all duration-300 hover:bg-white/5 group"
-                style={{ background: '#0E1F45' }}
-              >
-                <div className="w-full h-44 rounded-xl overflow-hidden mb-6 relative">
-                  <img
-                    src={card.img}
-                    alt={card.imgAlt}
-                    loading="lazy"
-                    className="w-full h-full object-cover object-top transition-transform duration-500 group-hover:scale-105"
-                  />
-                  <div className="absolute inset-0" style={{ background: 'linear-gradient(to top, rgba(14,31,69,0.7) 0%, transparent 60%)' }} aria-hidden="true" />
-                </div>
-                <p className="text-amber-400 text-xs font-semibold uppercase tracking-wider mb-2">{card.tag}</p>
-                <h3 className="text-white font-bold text-xl leading-snug mb-3" style={{ fontFamily: "'Syne', 'Inter', sans-serif" }}>{card.title}</h3>
-                <p className="text-white/60 text-sm leading-relaxed mb-4">{card.desc}</p>
-                <ul className="flex flex-col gap-2 mt-auto">
-                  {card.items.map((item) => (
-                    <li key={item} className="flex items-center gap-2 text-white/60 text-sm">
-                      <span className="w-1.5 h-1.5 rounded-full bg-teal-400 flex-shrink-0" aria-hidden="true" />
-                      {item}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
+            <p className="text-white/80 font-medium text-xl">
+              SoftHire handles all of it — so you can make the hire.
+            </p>
           </div>
         </div>
       </section>
@@ -87,99 +23,18 @@ const TalentSection = () => {
       {/* MARQUEE */}
       <div className="overflow-hidden whitespace-nowrap py-4" style={{ background: '#E8A830' }} aria-hidden="true">
         <div className="inline-block animate-marquee">
-          {['UK Student Visas', 'Skilled Worker Visas', 'Sponsor Licences', 'Graduate Visas', 'Partner & Dependant Visas', 'University Partnerships', 'Compliance Monitoring'].map((item, i) => (
+          {['Sponsor Licence Applications', 'Skilled Worker Visas', 'Certificate of Sponsorship', 'Right-to-Work Checks', 'Compliance Retainers', 'Home Office Audit Readiness', 'Key Personnel Setup'].map((item, i) => (
             <span key={i} className="inline-block mx-8 font-bold text-sm uppercase tracking-widest" style={{ color: '#0B1736' }}>
               {item} <span style={{ opacity: 0.3, marginLeft: '0.5rem', marginRight: '0.5rem' }}>◆</span>
             </span>
           ))}
-          {['UK Student Visas', 'Skilled Worker Visas', 'Sponsor Licences', 'Graduate Visas', 'Partner & Dependant Visas', 'University Partnerships', 'Compliance Monitoring'].map((item, i) => (
+          {['Sponsor Licence Applications', 'Skilled Worker Visas', 'Certificate of Sponsorship', 'Right-to-Work Checks', 'Compliance Retainers', 'Home Office Audit Readiness', 'Key Personnel Setup'].map((item, i) => (
             <span key={`b${i}`} className="inline-block mx-8 font-bold text-sm uppercase tracking-widest" style={{ color: '#0B1736' }}>
               {item} <span style={{ opacity: 0.3, marginLeft: '0.5rem', marginRight: '0.5rem' }}>◆</span>
             </span>
           ))}
         </div>
       </div>
-
-      {/* HOW IT WORKS */}
-      <section id="how-it-works" className="py-24 relative overflow-hidden" style={{ background: '#0B1736' }}>
-        <div className="absolute bottom-0 left-0 w-96 h-96 rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(46,100,200,0.12) 0%, transparent 70%)' }} aria-hidden="true" />
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-          <div className="grid lg:grid-cols-2 gap-16 items-center">
-            {/* Left: Steps */}
-            <div>
-              <div className="mb-10">
-                <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">How It Works</p>
-                <h2 className="text-white font-bold leading-tight tracking-tight" style={{ fontFamily: "'Syne', 'Inter', sans-serif", fontSize: 'clamp(2rem, 4vw, 3rem)' }}>
-                  From confused<br />
-                  to <span className="text-amber-400">confirmed</span> —<br />
-                  in weeks, not months.
-                </h2>
-                <p className="text-white/60 text-base leading-relaxed mt-3 max-w-md">
-                  Our technology removes the complexity. Our advisers handle the judgement. You just need to answer our questions.
-                </p>
-              </div>
-
-              <div className="flex flex-col">
-                {steps.map((step, i) => (
-                  <div
-                    key={step.num}
-                    className={`flex gap-5 py-5 group transition-all duration-200 hover:pl-2 ${i < steps.length - 1 ? 'border-b border-white/10' : ''}`}
-                  >
-                    <div className="w-8 h-8 rounded-full border border-amber-400/30 flex items-center justify-center flex-shrink-0 mt-0.5 text-amber-400 text-xs font-bold group-hover:bg-amber-400 group-hover:border-amber-400 transition-all duration-200" style={{ fontFamily: "'Syne', sans-serif" }}>
-                      <span className="group-hover:text-navy-900" style={{}}>{step.num}</span>
-                    </div>
-                    <div>
-                      <h3 className="text-white font-bold text-base mb-1">{step.title}</h3>
-                      <p className="text-white/55 text-sm leading-relaxed">{step.desc}</p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Right: Dashboard mockup */}
-            <div className="rounded-2xl overflow-hidden border border-white/10" style={{ background: '#172859' }}>
-              <div className="flex items-center gap-2 px-5 py-3 border-b border-white/10" style={{ background: 'rgba(11,23,54,0.8)' }}>
-                <span className="w-3 h-3 rounded-full bg-red-500" />
-                <span className="w-3 h-3 rounded-full bg-yellow-400" />
-                <span className="w-3 h-3 rounded-full bg-green-500" />
-                <span className="text-white/40 text-xs ml-2">SoftHire Case Dashboard</span>
-              </div>
-              <div className="p-6 flex flex-col gap-4">
-                {[
-                  { label: 'Identity Verification', pct: 100, status: 'Complete' },
-                  { label: 'Financial Evidence', pct: 95, status: '95%' },
-                  { label: 'English Language', pct: 88, status: '88%' },
-                ].map(({ label, pct, status }) => (
-                  <div key={label} className="flex flex-col gap-1.5">
-                    <div className="flex justify-between text-xs text-white/50">
-                      <span>{label}</span>
-                      <span className="text-amber-400 font-semibold">{status}</span>
-                    </div>
-                    <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
-                      <div className="h-full rounded-full" style={{ width: `${pct}%`, background: 'linear-gradient(90deg, #2EC4B6, #E8A830)' }} />
-                    </div>
-                  </div>
-                ))}
-                {[
-                  { label: 'TB Test Certificate', badge: 'Action Required', color: 'text-amber-400 bg-amber-400/15' },
-                  { label: 'Adviser Review', badge: 'In Progress', color: 'text-teal-400 bg-teal-400/15' },
-                  { label: 'Home Office Submission', badge: 'Scheduled', color: 'text-blue-400 bg-blue-400/15' },
-                ].map(({ label, badge, color }) => (
-                  <div key={label} className="flex items-center justify-between rounded-xl px-4 py-3 border border-white/8" style={{ background: 'rgba(255,255,255,0.03)' }}>
-                    <span className="text-white/60 text-sm">{label}</span>
-                    <span className={`text-xs font-semibold px-3 py-1 rounded-full ${color}`}>{badge}</span>
-                  </div>
-                ))}
-                <div className="mt-2 flex items-center gap-2 text-white/50 text-xs">
-                  <CheckCircle className="h-4 w-4 text-teal-400 flex-shrink-0" />
-                  Real-time updates — no chasing required
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
     </>
   );
 };


### PR DESCRIPTION
Rework content and components to pivot the site from student-focused visa services to employer-facing sponsor licence and compliance support. Updates include: revised SEO copy in App.tsx; a major overhaul of About.tsx (new Why, Industries, Process, Pricing, Trust & Testimonials sections, CTAs and tracking hooks); Hero.tsx rewritten for sponsor-licence messaging and updated CTAs/badges; Products.tsx simplified/renamed to services with three employer-oriented service cards and tracking; Contact CTA text and tracking updated. Also added/imported analytics tracking calls and UI icon updates to reflect the new employer-focused flow.