### PR TITLE
Hide price displays in About and Sponsor pages

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -254,10 +254,10 @@ const About = () => {
                   <span className="inline-block bg-amber-400 text-[#0B1736] text-xs font-bold uppercase tracking-wider px-3 py-1 rounded-full mb-4 w-fit">Most popular</span>
                 )}
                 <p className="text-amber-400 text-xs font-semibold uppercase tracking-wider mb-2">{card.title}</p>
-                <div className="flex items-end gap-1 mb-1">
+                <div className="flex items-end gap-1 mb-1 hidden">
                   <span className="text-white font-extrabold text-3xl leading-none" style={{ fontFamily: "'Syne', sans-serif" }}>{card.price}</span>
                 </div>
-                <p className="text-white/50 text-sm mb-6">{card.unit}</p>
+                <p className="text-white/50 text-sm mb-6 hidden">{card.unit}</p>
                 <ul className="flex flex-col gap-2.5 flex-grow mb-7">
                   {card.items.map((item) => (
                     <li key={item} className="flex items-start gap-2.5 text-white/65 text-sm">

--- a/src/components/pages/SponsorLicenceCostPage.tsx
+++ b/src/components/pages/SponsorLicenceCostPage.tsx
@@ -120,7 +120,7 @@ export default function SponsorLicenceCostPage() {
                           <div style={{ color: C.cream, fontWeight: 600, fontSize: '0.9rem' }}>{label}</div>
                           <div style={{ color: C.textMuted, fontSize: '0.8rem' }}>{note}</div>
                         </div>
-                        <div style={{ color: C.gold, fontFamily: "'Syne', sans-serif", fontWeight: 700, fontSize: '1.05rem', textAlign: 'right' }}>{amount}</div>
+                        <div style={{ color: C.gold, fontFamily: "'Syne', sans-serif", fontWeight: 700, fontSize: '1.05rem', textAlign: 'right', display: 'none' }}>{amount}</div>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
Temporarily hide visible pricing elements in the UI. About.tsx: added Tailwind "hidden" class to the price container and unit paragraph so card.price and card.unit are not shown. SponsorLicenceCostPage.tsx: added inline display: 'none' to the amount div to hide the monetary value. Keeps markup intact for easy re-enabling later.